### PR TITLE
FIx: _parent key is added twice. Need to remove "parent" key

### DIFF
--- a/src/core/components/settings/new-panel/ManualClasses.tsx
+++ b/src/core/components/settings/new-panel/ManualClasses.tsx
@@ -159,11 +159,11 @@ export function ManualClasses() {
           classes.map((cls: string) => (
             <div
               key={cls}
-              className="group relative flex cursor-default items-center gap-x-1 rounded-full border border-blue-600 bg-blue-500 p-px px-1.5 text-[11px] text-white hover:border-blue-900">
+              className="group relative truncate max-w-[260px] flex cursor-default items-center gap-x-1 rounded-full border border-blue-600 bg-blue-500 p-px px-1.5 text-[11px] text-white hover:border-blue-900">
               {cls}
               <Cross2Icon
                 onClick={() => removeClassesFromBlocks(selectedIds, [cls])}
-                className="invisible absolute right-1 hover:text-white group-hover:visible group-hover:cursor-pointer"
+                className="invisible absolute right-1 hover:text-white group-hover:visible group-hover:cursor-pointer "
               />
             </div>
           )),

--- a/src/core/components/sidepanels/panels/images/ImagesPanel.tsx
+++ b/src/core/components/sidepanels/panels/images/ImagesPanel.tsx
@@ -1,5 +1,7 @@
 import React, { Suspense, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../../../ui";
+import { useBuilderProp } from "../../../../hooks";
+import clsx from "clsx";
 
 const UnsplashImages = React.lazy(() => import("./UnsplashImages"));
 const UploadImages = React.lazy(() => import("./UploadImages"));
@@ -12,6 +14,13 @@ const ImagesPanel = ({
   onSelect?: (url: string) => void;
 }): React.JSX.Element => {
   const [tab, setTab] = useState("upload");
+
+  const uploadImageCallback = useBuilderProp("uploadMediaCallback");
+  const unsplashImageCallback = useBuilderProp("unsplashAccessKey");
+
+  const missingUploadImageCallback = uploadImageCallback === undefined;
+  const missingUnslashImageCallback = unsplashImageCallback === undefined;
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between rounded-md bg-background/30 p-1">
@@ -20,10 +29,14 @@ const ImagesPanel = ({
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as any)} className="flex h-full w-full flex-col py-2">
         <TabsList className="w-full">
-          <TabsTrigger value="upload" className="w-1/2">
+          <TabsTrigger
+            value="upload"
+            className={clsx(missingUploadImageCallback && "pointer-events-none opacity-50", "w-1/2")}>
             Upload
           </TabsTrigger>
-          <TabsTrigger value="unsplash" className="w-1/2">
+          <TabsTrigger
+            value="unsplash"
+            className={clsx(missingUnslashImageCallback && "pointer-events-none opacity-50", "w-1/2")}>
             Unsplash
           </TabsTrigger>
         </TabsList>

--- a/src/core/components/sidepanels/panels/images/ImagesPanel.tsx
+++ b/src/core/components/sidepanels/panels/images/ImagesPanel.tsx
@@ -1,7 +1,6 @@
 import React, { Suspense, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../../../ui";
 import { useBuilderProp } from "../../../../hooks";
-import clsx from "clsx";
 
 const UnsplashImages = React.lazy(() => import("./UnsplashImages"));
 const UploadImages = React.lazy(() => import("./UploadImages"));
@@ -13,33 +12,38 @@ const ImagesPanel = ({
   isModalView?: boolean;
   onSelect?: (url: string) => void;
 }): React.JSX.Element => {
-  const [tab, setTab] = useState("upload");
-
   const uploadImageCallback = useBuilderProp("uploadMediaCallback");
   const unsplashImageCallback = useBuilderProp("unsplashAccessKey");
 
   const missingUploadImageCallback = uploadImageCallback === undefined;
-  const missingUnslashImageCallback = unsplashImageCallback === undefined;
+  const missingUnsplashImageCallback = unsplashImageCallback === undefined;
 
+  const [tab, setTab] = useState(
+    missingUnsplashImageCallback ? "upload" : missingUploadImageCallback ? "unsplash" : "upload",
+  );
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between rounded-md bg-background/30 p-1">
-        <h1 className="px-1 font-semibold">{isModalView ? "Select or upload images" : "Images"}</h1>
+        <h1 className="px-1 font-semibold">
+          {isModalView && missingUploadImageCallback
+            ? "Unsplash images"
+            : isModalView
+              ? "Select or upload images"
+              : "Images"}
+        </h1>
       </div>
 
       <Tabs value={tab} onValueChange={(v) => setTab(v as any)} className="flex h-full w-full flex-col py-2">
-        <TabsList className="w-full">
-          <TabsTrigger
-            value="upload"
-            className={clsx(missingUploadImageCallback && "pointer-events-none opacity-50", "w-1/2")}>
-            Upload
-          </TabsTrigger>
-          <TabsTrigger
-            value="unsplash"
-            className={clsx(missingUnslashImageCallback && "pointer-events-none opacity-50", "w-1/2")}>
-            Unsplash
-          </TabsTrigger>
-        </TabsList>
+        {!(missingUploadImageCallback || missingUnsplashImageCallback) && (
+          <TabsList className="w-full">
+            <TabsTrigger value="upload" className="w-full">
+              Upload
+            </TabsTrigger>
+            <TabsTrigger value="unsplash" className="w-full">
+              Unsplash
+            </TabsTrigger>
+          </TabsList>
+        )}
         {tab === "unsplash" ? (
           <TabsContent value="unsplash" className="flex h-full flex-col overflow-hidden">
             <Suspense fallback={<div className="h-64 w-full animate-pulse bg-gray-100" />}>

--- a/src/core/functions/Blocks.ts
+++ b/src/core/functions/Blocks.ts
@@ -6,7 +6,7 @@ export const nestedToFlatArray = (nestedJson: Array<ChaiBlock>, parent: string |
   flatten(
     nestedJson.map((block: any) => {
       // eslint-disable-next-line no-param-reassign
-      block = parent !== null ? { ...block, parent } : block;
+      block = parent !== null ? { ...block, _parent: parent } : block;
       if (block.children && block.children.length) {
         const children = [...block.children];
         // eslint-disable-next-line no-param-reassign

--- a/src/core/functions/split-blocks.ts
+++ b/src/core/functions/split-blocks.ts
@@ -17,7 +17,7 @@ const nestedToFlatArray = (nestedJson: any, parent: any) =>
   flatten(
     nestedJson.map((block: ChaiBlock) => {
       // eslint-disable-next-line no-param-reassign
-      block = parent ? { ...block, parent } : { ...block };
+      block = parent ? { ...block, _parent: parent } : { ...block };
       if (block.children) {
         const children = [...block.children];
         // eslint-disable-next-line no-param-reassign

--- a/src/ui/widgets/rjsf/widgets/image.tsx
+++ b/src/ui/widgets/rjsf/widgets/image.tsx
@@ -1,32 +1,45 @@
 import { WidgetProps } from "@rjsf/utils";
 import { isEmpty } from "lodash-es";
 import ImagePickerModal from "../../../../core/components/sidepanels/panels/images/ImagePickerModal.tsx";
+import { useBuilderProp } from "../../../../core/builder.ts";
 
-const ImagePickerField = ({ value, onChange, id, onBlur }: WidgetProps) => (
-  <div className="mt-1.5 flex items-center gap-x-3">
-    {value ? (
-      <img src={value} className="h-20 w-20 overflow-hidden rounded-md border object-cover" alt="" />
-    ) : (
-      <ImagePickerModal onSelect={onChange}>
-        <div className="h-20 w-20 cursor-pointer rounded-md border bg-[radial-gradient(#AAA,transparent_1px)] duration-300 [background-size:10px_10px] hover:border-gray-400"></div>
-      </ImagePickerModal>
-    )}
-    <div className="flex w-3/5 flex-col">
-      <ImagePickerModal onSelect={onChange}>
-        <small className="cursor-pointer rounded-full bg-gray-600 px-2 py-1 text-center text-xs text-white hover:bg-gray-500 dark:bg-gray-700">
-          {value || !isEmpty(value) ? "Replace Image" : "Choose Image"}
-        </small>
-      </ImagePickerModal>
-      <small className="-pl-4 pt-2 text-center text-xs text-gray-600">OR</small>
-      <input
-        type="url"
-        className="text-xs"
-        placeholder="Enter image URL"
-        value={value}
-        onBlur={({ target: { value: url } }) => onBlur(id, url)}
-        onChange={(e) => onChange(e.target.value)}
-      />
+const ImagePickerField = ({ value, onChange, id, onBlur }: WidgetProps) => {
+  const uploadImageCallback = useBuilderProp("uploadMediaCallback");
+  const unsplashImageCallback = useBuilderProp("unsplashAccessKey");
+
+  const missingUploadImageCallback = uploadImageCallback === undefined;
+  const missingUnsplashImageCallback = unsplashImageCallback === undefined;
+
+  return (
+    <div className="mt-1.5 flex items-center gap-x-3">
+      {value ? (
+        <img src={value} className="h-20 w-20 overflow-hidden rounded-md border object-cover" alt="" />
+      ) : (
+        <ImagePickerModal onSelect={onChange}>
+          <div className="h-20 w-20 cursor-pointer rounded-md border bg-[radial-gradient(#AAA,transparent_1px)] duration-300 [background-size:10px_10px] hover:border-gray-400"></div>
+        </ImagePickerModal>
+      )}
+      <div className="flex w-3/5 flex-col">
+        {!missingUploadImageCallback && !missingUnsplashImageCallback && (
+          <>
+            <ImagePickerModal onSelect={onChange}>
+              <small className="cursor-pointer rounded-full bg-gray-600 px-2 py-1 text-center text-xs text-white hover:bg-gray-500 dark:bg-gray-700">
+                {value || !isEmpty(value) ? "Replace Image" : "Choose Image"}
+              </small>
+            </ImagePickerModal>
+            <small className="-pl-4 pt-2 text-center text-xs text-gray-600">OR</small>
+          </>
+        )}
+        <input
+          type="url"
+          className="text-xs"
+          placeholder="Enter image URL"
+          value={value}
+          onBlur={({ target: { value: url } }) => onBlur(id, url)}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 export { ImagePickerField };

--- a/src/ui/widgets/rjsf/widgets/image.tsx
+++ b/src/ui/widgets/rjsf/widgets/image.tsx
@@ -20,7 +20,7 @@ const ImagePickerField = ({ value, onChange, id, onBlur }: WidgetProps) => {
         </ImagePickerModal>
       )}
       <div className="flex w-3/5 flex-col">
-        {!missingUploadImageCallback && !missingUnsplashImageCallback && (
+        {!(missingUploadImageCallback && missingUnsplashImageCallback) && (
           <>
             <ImagePickerModal onSelect={onChange}>
               <small className="cursor-pointer rounded-full bg-gray-600 px-2 py-1 text-center text-xs text-white hover:bg-gray-500 dark:bg-gray-700">


### PR DESCRIPTION
## Summary
This PR addresses an issue in the `nestedToFlatArray` function within `Blocks.ts`, where the `parent` was added to the new blocks being created due to which `_parent` and `parent` are found twice. The fix involves changing the `parent` to `_parent: parent` in the object spread, ensuring it's only added once.

## Changes
- In `Blocks.ts`, specifically within the `nestedToFlatArray` function, modified the object spread that creates new blocks to prevent the `_parent` key from being added twice.

## Impact
- This change ensures the integrity of the data structure by preventing duplicate keys, which could potentially lead to confusion or errors in downstream processes that consume these blocks.
- It simplifies the object structure, making it more predictable and easier to understand.
- There should be no adverse impact on functionality, as this change merely removes a redundancy without altering the intended data relationships.

## Testing
- Ensure existing unit tests pass with the change.
- Add new unit tests to verify that the `_parent` key is only added once to each new block in various scenarios.
- Manual testing to confirm that the duplication of the `_parent` key is resolved and that the functionality related to block remains unaffected.