### PR TITLE
fix: fixed inconsistent border Radius and Icon for theme

### DIFF
--- a/src/core/components/layout/RootLayout.tsx
+++ b/src/core/components/layout/RootLayout.tsx
@@ -5,13 +5,12 @@ import { useRightPanel } from "../../hooks/useTheme.ts";
 import "../canvas/static/BlocksExternalDataProvider.tsx";
 import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../ui";
 import { motion } from "framer-motion";
-import { EditIcon, Layers, X } from "lucide-react";
+import { EditIcon, Layers, Paintbrush, X } from "lucide-react";
 import { Outline } from "../../main";
 import { CanvasTopBar } from "../canvas/topbar/CanvasTopBar.tsx";
 import CanvasArea from "../canvas/CanvasArea.tsx";
 import { AddBlocksDialog } from "./AddBlocksDialog.tsx";
 import { useTranslation } from "react-i18next";
-import { Settings } from "lucide-react";
 import SettingsPanel from "../settings/SettingsPanel.tsx";
 import { CHAI_BUILDER_EVENTS } from "../../events.ts";
 import { ChooseLayout } from "./ChooseLayout.tsx";
@@ -157,7 +156,7 @@ const RootLayout: ComponentType = () => {
                             {panel === "theme" ? (
                               <>
                                 <span className="flex items-center gap-2">
-                                  <Settings className="h-4 w-4 rtl:ml-2" />
+                                  <Paintbrush className="h-4 w-4 rtl:ml-2" />
                                   {t("Theme Settings")}
                                 </span>
                                 <Button

--- a/src/core/components/sidepanels/panels/theme-configuration/BorderRadiusInput.tsx
+++ b/src/core/components/sidepanels/panels/theme-configuration/BorderRadiusInput.tsx
@@ -1,7 +1,14 @@
 import { debounce } from "lodash-es";
 
-const BorderRadiusInput = ({ onChange, disabled }: { onChange: (value: string) => void; disabled: boolean }) => {
+type BorderRadiusInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+const BorderRadiusInput = ({ value, onChange, disabled }: BorderRadiusInputProps) => {
   const throttledChange = debounce((value: string) => onChange(value), 200);
+
   return (
     <input
       type="range"
@@ -9,7 +16,7 @@ const BorderRadiusInput = ({ onChange, disabled }: { onChange: (value: string) =
       step="1"
       max="30"
       disabled={disabled}
-      defaultValue="15"
+      defaultValue={value.replace("px", "")}
       onChange={(e) => throttledChange(e.target.value)}
       className="flex-1"
     />

--- a/src/core/components/sidepanels/panels/theme-configuration/ThemeConfigPanel.tsx
+++ b/src/core/components/sidepanels/panels/theme-configuration/ThemeConfigPanel.tsx
@@ -181,7 +181,6 @@ const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "
             <div className="flex items-center gap-4">
               <BorderRadiusInput
                 value={themeValues.borderRadius}
-                disabled={selectedPreset === "preset"}
                 onChange={handleBorderRadiusChange}
               />
               <span className="w-12 text-sm">{themeValues.borderRadius}</span>

--- a/src/core/components/sidepanels/panels/theme-configuration/ThemeConfigPanel.tsx
+++ b/src/core/components/sidepanels/panels/theme-configuration/ThemeConfigPanel.tsx
@@ -2,11 +2,12 @@ import * as React from "react";
 
 import { useBuilderProp } from "../../../../hooks/index.ts";
 import { useTranslation } from "react-i18next";
-import { Label, ScrollArea, Button, Switch } from "../../../../../ui";
+import { Label, ScrollArea, Button } from "../../../../../ui";
 import { cn } from "../../../../functions/Functions.ts";
 import { BorderRadiusInput, FontSelector, ColorPickerInput } from "./index.ts";
 import { useTheme, useThemeOptions } from "../../../../hooks/useTheme.ts";
-import { Sun, Moon } from "lucide-react";
+import { useDarkMode } from "../../../../hooks";
+
 import { get, set, capitalize } from "lodash-es";
 import { ChaiBuilderThemeValues } from "../../../../types/chaiBuilderEditorProps.ts";
 import { useDebouncedCallback } from "@react-hookz/web";
@@ -16,7 +17,7 @@ interface ThemeConfigProps {
 }
 
 const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "" }) => {
-  const [currentMode, setCurrentMode] = React.useState<"light" | "dark">("light");
+  const [isDarkMode] = useDarkMode();
   const [selectedPreset, setSelectedPreset] = React.useState<string>("");
   const themePresets = useBuilderProp("themePresets", []);
 
@@ -79,7 +80,7 @@ const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "
     (key: string, newValue: string) => {
       setThemeValues(() => {
         const prevColor = get(themeValues, `colors.${key}`);
-        if (currentMode === "light") {
+        if (!isDarkMode) {
           set(prevColor, 0, newValue);
         } else {
           set(prevColor, 1, newValue);
@@ -100,7 +101,7 @@ const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "
   const renderColorGroup = (group: any) => (
     <div className="grid grid-cols-1">
       {Object.entries(group.items).map(([key]: [string, [string, string]]) => {
-        const themeColor = get(themeValues, `colors.${key}.${currentMode === "light" ? 0 : 1}`);
+        const themeColor = get(themeValues, `colors.${key}.${isDarkMode ? 1 : 0}`);
         return (
           <div key={key} className="mt-1 flex items-center">
             <ColorPickerInput
@@ -178,7 +179,11 @@ const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "
           <div className="py-3">
             <h4 className="text-sm font-bold">{t("Border Radius")}</h4>
             <div className="flex items-center gap-4">
-              <BorderRadiusInput disabled={selectedPreset === "preset"} onChange={handleBorderRadiusChange} />
+              <BorderRadiusInput
+                value={themeValues.borderRadius}
+                disabled={selectedPreset === "preset"}
+                onChange={handleBorderRadiusChange}
+              />
               <span className="w-12 text-sm">{themeValues.borderRadius}</span>
             </div>
           </div>
@@ -191,18 +196,9 @@ const ThemeConfigPanel: React.FC<ThemeConfigProps> = React.memo(({ className = "
               <div className="flex items-center gap-2">
                 <h4 className="text-sm font-bold">{t("Colors")}</h4>
               </div>
-              <div className="flex items-center gap-2">
-                <Sun className="size-2 transition-all" />
-                <Switch
-                  checked={currentMode === "dark"}
-                  onCheckedChange={(checked) => setCurrentMode(checked ? "dark" : "light")}
-                  className="data-[state=checked]:bg-slate-800 data-[state=unchecked]:bg-slate-200"
-                />
-                <Moon className="size-2" />
-              </div>
             </div>
 
-            <div className="w-full space-y-4" key={currentMode}>
+            <div className="w-full space-y-4" key={isDarkMode ? "dark" : "light"}>
               {chaiThemeOptions.colors.map((group) => renderColorGroup(group))}
             </div>
           </div>


### PR DESCRIPTION
Fixed the following :
1. Border radius slider not working correctly in theme settings
2. Change the icon of theme settings to one same as topbar
3. Handle dark mode theming based on canvas dark mode instead of switch for colors