### PR TITLE
feat: ability to customize breakpoints component style

### DIFF
--- a/src/core/components/canvas/topbar/Breakpoints.tsx
+++ b/src/core/components/canvas/topbar/Breakpoints.tsx
@@ -14,6 +14,7 @@ import {
   HoverCardTrigger,
 } from "../../../../ui";
 import { useBuilderProp, useCanvasWidth, useSelectedBreakpoints } from "../../../hooks";
+import { cn } from "../../../functions/Functions";
 
 interface BreakpointItemType {
   breakpoint: string;
@@ -26,6 +27,19 @@ interface BreakpointItemType {
 interface BreakpointCardProps extends BreakpointItemType {
   currentBreakpoint: string;
   onClick: Function;
+}
+
+interface BreakpointCardProps extends BreakpointItemType {
+  currentBreakpoint: string;
+  onClick: Function;
+  iconContainerClasses?: string | undefined;
+  iconSelectedClasses?: string | undefined;
+}
+
+interface BreakPointClassProps {
+  iconListingClasses?: string | undefined;
+  iconContainerClasses?: string | undefined;
+  iconSelectedClasses?: string | undefined;
 }
 
 const TabletIcon = ({ landscape = false }) => (
@@ -95,15 +109,18 @@ const BreakpointCard = ({
   width,
   icon,
   onClick,
+  iconContainerClasses,
+  iconSelectedClasses
 }: BreakpointCardProps) => {
   const { t } = useTranslation();
   return (
     <HoverCard>
-      <HoverCardTrigger asChild>
+      <HoverCardTrigger className={cn(iconContainerClasses, iconSelectedClasses && breakpoint === currentBreakpoint ? iconSelectedClasses : "")} asChild>
         <Button
           onClick={() => onClick(width)}
           size="sm"
-          variant={breakpoint === currentBreakpoint ? "secondary" : "ghost"}>
+          variant={iconContainerClasses ? (breakpoint === currentBreakpoint ? "secondary" : "ghost") : 'default'}
+          >
           {icon}
         </Button>
       </HoverCardTrigger>
@@ -119,7 +136,11 @@ const BreakpointCard = ({
   );
 };
 
-export const Breakpoints = () => {
+export const Breakpoints = ({
+  iconListingClasses,
+  iconContainerClasses,
+  iconSelectedClasses
+}: BreakPointClassProps) => {
   const [, breakpoint, setNewWidth] = useCanvasWidth();
   const [selectedBreakpoints, setSelectedBreakpoints] = useSelectedBreakpoints();
   const { t } = useTranslation();
@@ -137,20 +158,20 @@ export const Breakpoints = () => {
 
   if (breakpoints.length < 4) {
     return (
-      <div className="flex items-center rounded-md">
+      <div className={cn("flex items-center rounded-md", iconListingClasses)}>
         {map(breakpoints, (bp) => (
-          <BreakpointCard {...bp} onClick={setNewWidth} key={bp.breakpoint} currentBreakpoint={breakpoint} />
+          <BreakpointCard iconSelectedClasses={iconSelectedClasses} iconContainerClasses={iconContainerClasses} {...bp} onClick={setNewWidth} key={bp.breakpoint} currentBreakpoint={breakpoint} />
         ))}
       </div>
     );
   }
 
   return (
-    <div className="flex items-center rounded-md">
+    <div className={cn("flex items-center rounded-md", iconListingClasses)}>
       {map(
         breakpoints.filter((bp: BreakpointItemType) => includes(selectedBreakpoints, toUpper(bp.breakpoint))),
         (bp: BreakpointItemType) => (
-          <BreakpointCard {...bp} onClick={setNewWidth} key={bp.breakpoint} currentBreakpoint={breakpoint} />
+          <BreakpointCard iconSelectedClasses={iconSelectedClasses} iconContainerClasses={iconContainerClasses} {...bp} onClick={setNewWidth} key={bp.breakpoint} currentBreakpoint={breakpoint} />
         ),
       )}
       <DropdownMenu>

--- a/src/core/components/canvas/topbar/Breakpoints.tsx
+++ b/src/core/components/canvas/topbar/Breakpoints.tsx
@@ -119,7 +119,7 @@ const BreakpointCard = ({
         <Button
           onClick={() => onClick(width)}
           size="sm"
-          variant={iconContainerClasses ? (breakpoint === currentBreakpoint ? "secondary" : "ghost") : 'default'}
+          variant={iconContainerClasses ? 'default' : (breakpoint === currentBreakpoint ? "secondary" : "ghost")}
           >
           {icon}
         </Button>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6cfc9f5d-ec97-4a1a-8596-3d97dd6d9dbd)

We had a few Design related requirements that weren't currently supported by the Breakpoints component, so I added the ability to put custom default classes for the components icon container, the components listing container, and the component's selected state. Please Review @surajair 