### PR TITLE
feat: undoredo component style is now changeable through props

### DIFF
--- a/src/core/components/canvas/topbar/UndoRedo.tsx
+++ b/src/core/components/canvas/topbar/UndoRedo.tsx
@@ -1,15 +1,31 @@
 import { ResetIcon } from "@radix-ui/react-icons";
 import { Button } from "../../../../ui";
 import { useUndoManager } from "../../../history/useUndoManager.ts";
+import { cn } from "../../../functions/Functions.ts";
 
-export const UndoRedo = () => {
+interface ButtonProps {
+  defaultClasses?: string | undefined
+  onDisabledClasses?: string | undefined
+}
+
+interface UndoRedoProps {
+  containerClasses?: string | undefined,
+  undoButtonProps?: ButtonProps,
+  redoButtonProps?: ButtonProps
+}
+
+export const UndoRedo = ({
+  containerClasses,
+  redoButtonProps,
+  undoButtonProps
+}: UndoRedoProps) => {
   const { hasUndo, hasRedo, undo, redo } = useUndoManager();
   return (
-    <div className="flex items-center">
-      <Button disabled={!hasUndo()} size="sm" onClick={undo as any} className="rounded-full" variant="ghost">
+    <div className={cn("flex items-center", containerClasses)}>
+      <Button disabled={!hasUndo()} size="sm" onClick={undo as any} className={cn("rounded-full", undoButtonProps?.defaultClasses, !hasUndo() && undoButtonProps?.onDisabledClasses)} variant="ghost">
         <ResetIcon />
       </Button>
-      <Button disabled={!hasRedo()} onClick={redo as any} size="sm" className="rounded-full" variant="ghost">
+      <Button disabled={!hasRedo()} onClick={redo as any} size="sm" className={cn("rounded-full", redoButtonProps?.defaultClasses, !hasRedo() && redoButtonProps?.onDisabledClasses)} variant="ghost">
         <ResetIcon className="rotate-180 scale-y-[-1] transform" />
       </Button>
     </div>


### PR DESCRIPTION
Similar to the last pull request, added props to the undoredo component that allow changing it's native styles, making it easier for users to attend it's own builders design specifications. 

link to the last PR...
https://github.com/chaibuilder/sdk/pull/78