### PR TITLE
fix: fixed the canvas breaking due to undefined values

### DIFF
--- a/src/web-blocks/form/select.tsx
+++ b/src/web-blocks/form/select.tsx
@@ -24,7 +24,9 @@ const SelectBlock = (props: ChaiBlockComponentProps<SelectProps>) => {
           {placeholder}
         </option>
         {map(options, (option) => (
-          <option key={option.value} value={option.value} dangerouslySetInnerHTML={{ __html: option.label }} />
+          <option key={option?.value} value={option?.value}>
+            {option?.label}
+          </option>
         ))}
       </select>
     );
@@ -38,7 +40,9 @@ const SelectBlock = (props: ChaiBlockComponentProps<SelectProps>) => {
           {placeholder}
         </option>
         {map(options, (option) => (
-          <option key={option.value} value={option.value} dangerouslySetInnerHTML={{ __html: option.label }} />
+          <option key={option?.value} value={option?.value}>
+            {option?.label}
+          </option>
         ))}
       </select>
     </div>


### PR DESCRIPTION
I have removed the "dangerouslySetInnerHtml" and instead used simple <option>. I think we don't need this. Since we are only using label for that.

Fix: Used optional chaining to fix the undefined errors.