### PR TITLE
feat: finish implementation of form alpine js attributes

### DIFF
--- a/src/web-blocks/form/form.tsx
+++ b/src/web-blocks/form/form.tsx
@@ -20,7 +20,24 @@ const FormBlock = (
   }
 
   const alpineAttrs = {
-    "x-data": "{}",
+    "x-data": `{
+        formStatus: '',
+        async post() {
+            try {
+                const formData = new FormData($el); // Collect all form data
+                const response = await fetch($el.action, {
+                    method: $el.method,
+                    body: formData
+                });
+                if (!response.ok) throw new Error();
+                this.formStatus = 'SUCCESS';
+                $el.querySelector('[x-html]').innerHTML = $el.dataset.success;
+            } catch (error) {
+                this.formStatus = 'ERROR';
+                $el.querySelector('[x-html]').innerHTML = $el.dataset.error;
+            }
+        }
+    }`,
     "x-on:submit.prevent": "post",
   };
   const formResponseAttr = {

--- a/src/web-blocks/form/form.tsx
+++ b/src/web-blocks/form/form.tsx
@@ -24,7 +24,7 @@ const FormBlock = (
         formStatus: '',
         async post() {
             try {
-                const formData = new FormData($el); // Collect all form data
+                const formData = new FormData($el);
                 const response = await fetch($el.action, {
                     method: $el.method,
                     body: formData


### PR DESCRIPTION
I might not be seeing the whole picture somehow, but it seems to me as if the form functionality just wasn't finished. When alpinejs was not loaded on the webpage, the form would simply redirect the user to the URL configured in the form. When alpinejs was loaded on the page, it would work as shown below: with some data and things not being able to be used by alpinejs because they weren't even created in the first place. 
![image](https://github.com/user-attachments/assets/7fd1393b-b53c-473b-8cb4-8290110b012f)

The error and success messages also were not working. Now they are.
