### PR TITLE
feat: add internal panel flag and improve sidebar header styling

### DIFF
--- a/src/core/components/layout/RootLayout.tsx
+++ b/src/core/components/layout/RootLayout.tsx
@@ -27,6 +27,7 @@ function useSidebarMenuItems() {
       {
         icon: <Layers size={20} />,
         label: "Outline",
+        isInternal: true,
         component: () => (
           <div className="-mt-8">
             <Outline />
@@ -119,13 +120,13 @@ const RootLayout: ComponentType = () => {
               transition={{ duration: 0.3, ease: "easeInOut" }}>
               {activePanelIndex !== null && (
                 <div className="no-scrollbar flex h-full flex-col overflow-hidden px-3 py-2">
-                  <div className="absolute top-2 flex h-10 items-center space-x-1 py-2 text-base font-bold">
+                  <div
+                    className={`absolute top-2 z-50 flex h-10 items-center space-x-1 bg-green-100 bg-white py-2 text-base font-bold ${get(sidebarMenuItems, `${activePanelIndex}.isInternal`, false) ? "" : "w-64"}`}>
                     <span className="rtl:ml-2 rtl:inline-block">
                       {get(sidebarMenuItems, `${activePanelIndex}.icon`, null)}
                     </span>
                     <span>{t(sidebarMenuItems[activePanelIndex].label)}</span>
                   </div>
-
                   <div className="no-scrollbar max-h-full overflow-y-auto pt-10">
                     <Suspense fallback={<div>Loading...</div>}>
                       {React.createElement(get(sidebarMenuItems, `${activePanelIndex}.component`, null), {})}

--- a/src/web-blocks/form/label.tsx
+++ b/src/web-blocks/form/label.tsx
@@ -33,6 +33,8 @@ const Config = {
       },
     },
   }),
+  aiProps: ["content"],
+  i18nProps: ["content"],
 };
 
 export { LabelBlock as Component, Config };


### PR DESCRIPTION
Issue: 
- Due to not occupy entire width by header back content was visible
- But in outline case there is absolute position element out of container for that case added condition, in this case tree component inbuild doesn't allow to show overflow data

Issue images:
![Screenshot 2025-02-11 135632](https://github.com/user-attachments/assets/22580d68-9002-436a-a488-8dc3cf23e746)
![Screenshot 2025-02-11 135620](https://github.com/user-attachments/assets/794b1016-d1b1-4bf2-9adc-77932f5e6f20)
