### PR TITLE
Configure GitHub Actions to release the package to npm registry on creating a specific tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release to npm
+
+on:
+  push:
+    tags:
+      - 'v-*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install --no-frozen-lockfile
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "e2e": "playwright test",
     "e2e:report": "playwright show-report",
     "e2e:ui": "playwright test --ui",
-    "prepare": "husky"
+    "prepare": "husky",
+    "publish": "npm publish"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Fixes #184

Add GitHub Action workflow to release package to npm on tag creation.

* **New GitHub Action Workflow**: Create `.github/workflows/release.yml` to trigger on tag creation matching `v-*.*.*`.
  * Checkout repository using `actions/checkout@v3`.
  * Set up Node.js using `actions/setup-node@v3` with `node-version: 18`.
  * Install dependencies using `npm install -g pnpm && pnpm install --no-frozen-lockfile`.
  * Build the project using `pnpm run build`.
  * Publish the package to npm using `npm publish` with `NPM_TOKEN` from repository secrets.

* **package.json**: Add `publish` script to `scripts` section to publish the package to npm.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chaibuilder/sdk/pull/185?shareId=fd42a952-87e1-4190-ab25-c72ef7bc2030).