### PR TITLE
feat: improved render-chai-block apis and data providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "peerDependencies": {
-    "@chaibuilder/runtime": "2.0.7",
+    "@chaibuilder/runtime": "2.0.8",
     "@types/react": "*",
     "@types/react-dom": "*",
     "jotai": "2.12.1",
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^1.2.2",
-    "@chaibuilder/runtime": "2.0.7",
+    "@chaibuilder/runtime": "2.0.8",
     "@floating-ui/dom": "1.6.13",
     "@floating-ui/react-dom": "2.1.2",
     "@mhsdesign/jit-browser-tailwindcss": "0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(react@19.1.0)(zod@3.24.1)
       '@chaibuilder/runtime':
-        specifier: 2.0.7
-        version: 2.0.7(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 2.0.8
+        version: 2.0.8(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@floating-ui/dom':
         specifier: 1.6.13
         version: 1.6.13
@@ -556,8 +556,8 @@ packages:
   '@bundled-es-modules/tough-cookie@0.1.6':
     resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
-  '@chaibuilder/runtime@2.0.7':
-    resolution: {integrity: sha512-6Fo0wRnyNr5QC5q/oCPGOFF67ncjMYBZZEDT7wtFejDK+pSwMnRf3yPSg5S5gZaLuEil061F8PAayzTtTIt6Fg==}
+  '@chaibuilder/runtime@2.0.8':
+    resolution: {integrity: sha512-/E3+85pASMU5YpImsPej4VF7ygGgw752qbqAjA7czfVz4mxBhMmBSmeNv43cVX6O/bi/2XOIsDTy2cv66MFYGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5661,7 +5661,7 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
 
-  '@chaibuilder/runtime@2.0.7(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chaibuilder/runtime@2.0.8(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@rjsf/utils': 5.24.2(react@19.1.0)
       clsx: 2.1.1

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -25,6 +25,7 @@ function Preview() {
       <style>{themeVars}</style>
       <style>{allStyles}</style>
       <RenderChaiBlocks
+        lang="fr"
         externalData={{
           vehicle: {
             title: "Hyundai i20 Active - 1.0 MPI - 2015",

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -39,6 +39,17 @@ function Preview() {
             description: "This is a description of my page",
           },
         }}
+        metadata={{
+          vehicle: {
+            title: "Hyundai i20 Active - 1.0 MPI - 2015",
+          },
+        }}
+        forwardProps={{
+          slug: "hyundai-i20-active-10-mpi-2015",
+          vehicle: {
+            title: "Hyundai i20 Active - 1.0 MPI - 2015",
+          },
+        }}
         blocks={blocks}
         dataProviderMetadataCallback={(block, meta) => {
           console.log("meta", meta);

--- a/src/_demo/blocks/CollectionList.tsx
+++ b/src/_demo/blocks/CollectionList.tsx
@@ -27,8 +27,19 @@ type ServerProps = {
   items: any[];
 };
 
-const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerProps>) => {
-  const { title1, blockProps, wrapperStyles, listStyles, itemStyles, items, tag, showTitle, binding } = props;
+type ForwardProps = {
+  draft: boolean;
+  slug: string;
+  vehicle: {
+    title: string;
+  };
+};
+
+const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerProps & ForwardProps>) => {
+  const { title1, blockProps, wrapperStyles, listStyles, itemStyles, items, tag, showTitle, binding, vehicle, slug } =
+    props;
+  console.log(" vehicle", vehicle);
+  console.log("slug", slug);
   return (
     <div {...blockProps} {...wrapperStyles}>
       {showTitle && <h1>{title1}</h1>}

--- a/src/_demo/blocks/CollectionList.tsx
+++ b/src/_demo/blocks/CollectionList.tsx
@@ -28,7 +28,6 @@ type ServerProps = {
 };
 
 type ForwardProps = {
-  draft: boolean;
   slug: string;
   vehicle: {
     title: string;
@@ -36,10 +35,25 @@ type ForwardProps = {
 };
 
 const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerProps & ForwardProps>) => {
-  const { title1, blockProps, wrapperStyles, listStyles, itemStyles, items, tag, showTitle, binding, vehicle, slug } =
-    props;
+  const {
+    title1,
+    blockProps,
+    wrapperStyles,
+    listStyles,
+    itemStyles,
+    items,
+    tag,
+    showTitle,
+    binding,
+    vehicle,
+    slug,
+    draft,
+    inBuilder,
+    lang,
+  } = props;
   console.log(" vehicle", vehicle);
   console.log("slug", slug);
+  console.log("draft", draft, inBuilder, lang);
   return (
     <div {...blockProps} {...wrapperStyles}>
       {showTitle && <h1>{title1}</h1>}

--- a/src/core/components/sidepanels/panels/add-blocks/libraries-panel.tsx
+++ b/src/core/components/sidepanels/panels/add-blocks/libraries-panel.tsx
@@ -230,7 +230,7 @@ const UILibrarySection = ({ parentId, position }: { parentId?: string; position?
   return (
     <>
       <div className="flex h-full max-h-full flex-col">
-        <div className="flex items-center gap-2 border-b border-border p-2">
+        <div className="flex items-center gap-2 border-border py-2">
           <div className="relative w-full">
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input

--- a/src/core/lib.ts
+++ b/src/core/lib.ts
@@ -1,5 +1,5 @@
+export * from "../render/functions";
 export { generateUUID, getBreakpointValue } from "./functions/Functions.ts";
 export { getBlocksFromHTML } from "./import-html/html-to-json";
-export * from "../render/functions";
 
-export { getStylesForBlocks } from "../render/getTailwindCSS.ts";
+export { getStylesForBlocks } from "../render/get-tailwind-css.ts";

--- a/src/render/async-props-block.tsx
+++ b/src/render/async-props-block.tsx
@@ -5,7 +5,8 @@ import React, { Suspense } from "react";
 type DataProvider =
   | ((block: ChaiBlock, lang: string, metadata: any) => Record<string, any> | Promise<Record<string, any>>)
   | ((props: {
-      block: ChaiBlock;
+      draft: boolean;
+      inBuilder: boolean;
       lang: string;
       [key: string]: any;
     }) => Record<string, any> | Promise<Record<string, any>>);
@@ -23,7 +24,7 @@ export default async function AsyncPropsBlock(props: {
   draft?: boolean;
 }) {
   const dataProps = props.forwardProps
-    ? await (props.dataProvider as (props: { draft?: boolean; lang: string; [key: string]: any }) => any)({
+    ? await (props.dataProvider as (props: { draft: boolean; lang: string; [key: string]: any }) => any)({
         ...props.forwardProps,
         ...props.block,
         lang: props.lang,

--- a/src/render/async-props-block.tsx
+++ b/src/render/async-props-block.tsx
@@ -2,16 +2,39 @@ import { ChaiBlock } from "@chaibuilder/runtime";
 import { has, omit } from "lodash-es";
 import React, { Suspense } from "react";
 
+type DataProvider =
+  | ((block: ChaiBlock, lang: string, metadata: any) => Record<string, any> | Promise<Record<string, any>>)
+  | ((props: {
+      block: ChaiBlock;
+      lang: string;
+      [key: string]: any;
+    }) => Record<string, any> | Promise<Record<string, any>>);
+
 export default async function AsyncPropsBlock(props: {
   lang: string;
+  inBuilder: boolean;
   metadata: Record<string, any>;
+  forwardProps: Record<string, any>;
   component: React.ComponentType<any>;
   props: any;
   block: ChaiBlock;
-  dataProvider: (block: ChaiBlock, lang: string, metadata: any) => Record<string, any>;
+  dataProvider: DataProvider;
   dataProviderMetadataCallback: (block: ChaiBlock, meta: Record<string, any>) => void;
+  draft?: boolean;
 }) {
-  const dataProps = await props?.dataProvider(props.block, props.lang, props.metadata);
+  const dataProps = props.forwardProps
+    ? await (props.dataProvider as (props: { draft?: boolean; lang: string; [key: string]: any }) => any)({
+        ...props.forwardProps,
+        ...props.block,
+        lang: props.lang,
+        draft: props.draft,
+        inBuilder: props.inBuilder,
+      })
+    : await (props.dataProvider as (block: ChaiBlock, lang: string, metadata: any) => any)(
+        props.block,
+        props.lang,
+        props.metadata ?? {},
+      );
 
   if (has(dataProps, "$metadata")) {
     props.dataProviderMetadataCallback(props.block, dataProps.$metadata);

--- a/src/render/get-tailwind-css.ts
+++ b/src/render/get-tailwind-css.ts
@@ -4,8 +4,8 @@ import twContainer from "@tailwindcss/container-queries";
 import twForms from "@tailwindcss/forms";
 import twTypography from "@tailwindcss/typography";
 import { defaultThemeOptions } from "../core/hooks/defaultThemeOptions.ts";
-import { chaiBuilderPlugin } from "../tailwind";
 import { getChaiBuilderTheme } from "../tailwind/getChaiBuilderTheme.ts";
+import { chaiBuilderPlugin } from "../tailwind/index.ts";
 import { ChaiBlock } from "../types/chai-block.ts";
 import { ChaiBuilderThemeOptions } from "../types/chaibuilder-editor-props.ts";
 
@@ -35,6 +35,13 @@ async function getTailwindCSS(
   );
 }
 
+/**
+ * Get the tailwind css for the blocks
+ * @param blocks - The blocks to get the tailwind css for
+ * @param themeOptions - The theme options to use
+ * @param includeBaseStyles - Whether to include the base styles
+ * @returns The tailwind css for the blocks
+ */
 const getBlocksTailwindCSS = (
   blocks: ChaiBlock[],
   themeOptions: ChaiBuilderThemeOptions,
@@ -46,6 +53,13 @@ const getBlocksTailwindCSS = (
   return getTailwindCSS(themeOptions, [blocksString], [], "", includeBaseStyles);
 };
 
+/**
+ * Get the tailwind css for the blocks
+ * @param blocks - The blocks to get the tailwind css for
+ * @param themeOptions - The theme options to use
+ * @param includeBaseStyles - Whether to include the base styles
+ * @returns The tailwind css for the blocks
+ */
 export const getStylesForBlocks = async (
   blocks: ChaiBlock[],
   themeOptions: ChaiBuilderThemeOptions = defaultThemeOptions,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,5 +4,5 @@ export {
   getThemeFontsLinkMarkup,
 } from "../core/components/canvas/static/chai-theme-helpers.ts";
 export { convertToBlocks } from "./functions.ts";
-export { getStylesForBlocks } from "./getTailwindCSS.ts";
+export { getStylesForBlocks } from "./get-tailwind-css.ts";
 export { RenderChaiBlocks } from "./render-chai-blocks.tsx";


### PR DESCRIPTION
New:
- Added `forwardProps` to send additional props to all blocks rendered using Chai Builder.
- Changed the api signature of data providers