### PR TITLE
Page-props-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "peerDependencies": {
-    "@chaibuilder/runtime": "2.0.8",
+    "@chaibuilder/runtime": "2.1.0",
     "@types/react": "*",
     "@types/react-dom": "*",
     "jotai": "2.12.1",
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^1.2.2",
-    "@chaibuilder/runtime": "2.0.8",
+    "@chaibuilder/runtime": "2.1.0",
     "@floating-ui/dom": "1.6.13",
     "@floating-ui/react-dom": "2.1.2",
     "@mhsdesign/jit-browser-tailwindcss": "0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2(react@19.1.0)(zod@3.24.1)
       '@chaibuilder/runtime':
-        specifier: 2.0.8
-        version: 2.0.8(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 2.1.0
+        version: 2.1.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@floating-ui/dom':
         specifier: 1.6.13
         version: 1.6.13
@@ -556,8 +556,8 @@ packages:
   '@bundled-es-modules/tough-cookie@0.1.6':
     resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
 
-  '@chaibuilder/runtime@2.0.8':
-    resolution: {integrity: sha512-/E3+85pASMU5YpImsPej4VF7ygGgw752qbqAjA7czfVz4mxBhMmBSmeNv43cVX6O/bi/2XOIsDTy2cv66MFYGA==}
+  '@chaibuilder/runtime@2.1.0':
+    resolution: {integrity: sha512-QfOlA6tKLUdE66rokPVlLFRU1B61Udyqp4xWJpsOoS+nv36qLuQTxPLlFPQPSVCHFfEYzGSiPDw2CGFkwDpwlw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5661,7 +5661,7 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
 
-  '@chaibuilder/runtime@2.0.8(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chaibuilder/runtime@2.1.0(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@rjsf/utils': 5.24.2(react@19.1.0)
       clsx: 2.1.1

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -26,6 +26,7 @@ function Preview() {
       <style>{allStyles}</style>
       <RenderChaiBlocks
         lang="fr"
+        fallbackLang="en"
         externalData={{
           vehicle: {
             title: "Hyundai i20 Active - 1.0 MPI - 2015",
@@ -40,17 +41,13 @@ function Preview() {
             description: "This is a description of my page",
           },
         }}
-        metadata={{
-          vehicle: {
-            title: "Hyundai i20 Active - 1.0 MPI - 2015",
-          },
-        }}
-        forwardProps={{
+        pageProps={{
           slug: "hyundai-i20-active-10-mpi-2015",
           vehicle: {
             title: "Hyundai i20 Active - 1.0 MPI - 2015",
           },
         }}
+        draft={true}
         blocks={blocks}
         dataProviderMetadataCallback={(block, meta) => {
           console.log("meta", meta);

--- a/src/_demo/blocks/CollectionList.tsx
+++ b/src/_demo/blocks/CollectionList.tsx
@@ -27,14 +27,7 @@ type ServerProps = {
   items: any[];
 };
 
-type ForwardProps = {
-  slug: string;
-  vehicle: {
-    title: string;
-  };
-};
-
-const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerProps & ForwardProps>) => {
+const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerProps>) => {
   const {
     title1,
     blockProps,
@@ -45,15 +38,12 @@ const Component = (props: ChaiBlockComponentProps<CollectionListProps & ServerPr
     tag,
     showTitle,
     binding,
-    vehicle,
-    slug,
     draft,
     inBuilder,
     lang,
+    pageProps,
   } = props;
-  console.log(" vehicle", vehicle);
-  console.log("slug", slug);
-  console.log("draft", draft, inBuilder, lang);
+  console.log("draft", pageProps, draft, inBuilder, lang);
   return (
     <div {...blockProps} {...wrapperStyles}>
       {showTitle && <h1>{title1}</h1>}

--- a/src/render/async-props-block.tsx
+++ b/src/render/async-props-block.tsx
@@ -1,41 +1,33 @@
-import { ChaiBlock } from "@chaibuilder/runtime";
+import { ChaiBlock, ChaiPageProps } from "@chaibuilder/runtime";
 import { has, omit } from "lodash-es";
 import React, { Suspense } from "react";
 
-type DataProvider =
-  | ((block: ChaiBlock, lang: string, metadata: any) => Record<string, any> | Promise<Record<string, any>>)
-  | ((props: {
-      draft: boolean;
-      inBuilder: boolean;
-      lang: string;
-      [key: string]: any;
-    }) => Record<string, any> | Promise<Record<string, any>>);
+type DataProvider = (props: {
+  draft: boolean;
+  inBuilder: boolean;
+  lang: string;
+  block: ChaiBlock;
+  pageProps: ChaiPageProps;
+}) => Record<string, any> | Promise<Record<string, any>>;
 
 export default async function AsyncPropsBlock(props: {
   lang: string;
   inBuilder: boolean;
-  metadata: Record<string, any>;
-  forwardProps: Record<string, any>;
+  pageProps: ChaiPageProps;
   component: React.ComponentType<any>;
   props: any;
   block: ChaiBlock;
   dataProvider: DataProvider;
   dataProviderMetadataCallback: (block: ChaiBlock, meta: Record<string, any>) => void;
-  draft?: boolean;
+  draft: boolean;
 }) {
-  const dataProps = props.forwardProps
-    ? await (props.dataProvider as (props: { draft: boolean; lang: string; [key: string]: any }) => any)({
-        ...props.forwardProps,
-        ...props.block,
-        lang: props.lang,
-        draft: props.draft,
-        inBuilder: props.inBuilder,
-      })
-    : await (props.dataProvider as (block: ChaiBlock, lang: string, metadata: any) => any)(
-        props.block,
-        props.lang,
-        props.metadata ?? {},
-      );
+  const dataProps = await props.dataProvider({
+    pageProps: props.pageProps,
+    block: props.block,
+    lang: props.lang,
+    draft: props.draft,
+    inBuilder: props.inBuilder,
+  });
 
   if (has(dataProps, "$metadata")) {
     props.dataProviderMetadataCallback(props.block, dataProps.$metadata);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+import { ChaiPageProps } from "@chaibuilder/runtime";
 import type { ChaiBuilderEditorProps } from "./chaibuilder-editor-props.ts";
 
 export type { ChaiBuilderEditorProps };
@@ -7,3 +8,5 @@ export type ChaiPage = {
   uuid?: string;
   name?: string;
 };
+
+export type { ChaiPageProps };


### PR DESCRIPTION
renamed the forwardProps prop to `pageProps`.

Also, updated the dataProviders to pass block, pageProps, draft, lang, inBuilder as separate keys instead of mergin into one