### PR TITLE
feat: added close() props to sidepanels 

### DIFF
--- a/src/_demo/panels/panel.tsx
+++ b/src/_demo/panels/panel.tsx
@@ -1,41 +1,47 @@
-import { registerChaiSidebarPanel, useBlocksStore } from "@/core/main";
+import { registerChaiSidebarPanel } from "@/core/main";
 import { Button } from "@/ui/shadcn/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/shadcn/components/ui/popover";
 import { ThermometerIcon } from "lucide-react";
 
-const Panel1Button = ({ isActive, show }: { isActive: boolean; show: () => void }) => {
-  return (
-    <Button variant={isActive ? "default" : "ghost"} size="icon" onClick={show}>
-      <ThermometerIcon />
-    </Button>
-  );
-};
+// const Panel1Button = ({ isActive, show }: { isActive: boolean; show: () => void }) => {
+//   return (
+//     <Button variant={isActive ? "default" : "ghost"} size="icon" onClick={show}>
+//       <ThermometerIcon />
+//     </Button>
+//   );
+// };
 
-registerChaiSidebarPanel("panel-1", {
-  panel: () => <div>Panel 1</div>,
-  button: Panel1Button,
-  label: "Panel 1",
-  position: "top",
-});
+// registerChaiSidebarPanel("panel-1", {
+//   panel: () => <div>Panel 1</div>,
+//   button: Panel1Button,
+//   label: "Panel 1",
+//   position: "top",
+// });
 
-const WhenEmptyCanvasButton = ({ isActive, show }: { isActive: boolean; show: () => void }) => {
-  const [blocks] = useBlocksStore();
-  if (blocks.length > 0) {
-    return null;
-  }
-  return (
-    <Button variant={isActive ? "default" : "ghost"} size="icon" onClick={show}>
-      <ThermometerIcon />
-    </Button>
-  );
-};
+// const WhenEmptyCanvasButton = ({ isActive, show }: { isActive: boolean; show: () => void }) => {
+//   const [blocks] = useBlocksStore();
+//   if (blocks.length > 0) {
+//     return null;
+//   }
+//   return (
+//     <Button variant={isActive ? "default" : "ghost"} size="icon" onClick={show}>
+//       <ThermometerIcon />
+//     </Button>
+//   );
+// };
 
-registerChaiSidebarPanel("when-empty-canvas", {
-  panel: () => <div>WhenEmptyCanvas</div>,
-  button: WhenEmptyCanvasButton,
-  label: "WhenEmptyCanvas",
-  position: "top",
-});
+// registerChaiSidebarPanel("when-empty-canvas", {
+//   panel: ({ close }: { close: () => void }) => (
+//     <div>
+//       WhenEmptyCanvas
+//       <Button onClick={close}>Close</Button>
+//     </div>
+//   ),
+//   button: WhenEmptyCanvasButton,
+//   label: "WhenEmptyCanvas",
+//   position: "top",
+//   view: "modal",
+// });
 
 const PopoverButton = () => {
   return (

--- a/src/core/components/layout/root-layout.tsx
+++ b/src/core/components/layout/root-layout.tsx
@@ -157,6 +157,10 @@ const RootLayout: ComponentType = () => {
     setActivePanel(lastStandardPanelRef.current);
   };
 
+  const closeNonStandardPanel = useCallback(() => {
+    setActivePanel("outline");
+  }, [setActivePanel]);
+
   useEffect(() => {
     if (!find(sidebarMenuItems, { id: activePanel })) {
       setActivePanel("outline");
@@ -303,7 +307,9 @@ const RootLayout: ComponentType = () => {
                   </SheetHeader>
                   <div className="h-full max-h-full overflow-y-auto p-4">
                     <Suspense fallback={<div>Loading...</div>}>
-                      {React.createElement(get(activePanelItem, "panel", NoopComponent), {})}
+                      {React.createElement(get(activePanelItem, "panel", NoopComponent), {
+                        close: closeNonStandardPanel,
+                      })}
                     </Suspense>
                   </div>
                 </SheetContent>
@@ -321,7 +327,9 @@ const RootLayout: ComponentType = () => {
                   </DialogHeader>
                   <div className="max-h-[70vh] overflow-y-auto p-4">
                     <Suspense fallback={<div>Loading...</div>}>
-                      {React.createElement(get(activePanelItem, "panel", NoopComponent), {})}
+                      {React.createElement(get(activePanelItem, "panel", NoopComponent), {
+                        close: closeNonStandardPanel,
+                      })}
                     </Suspense>
                   </div>
                 </DialogContent>
@@ -353,7 +361,9 @@ const RootLayout: ComponentType = () => {
                     </div>
                     <div className="flex-1 overflow-y-auto p-4">
                       <Suspense fallback={<div>Loading...</div>}>
-                        {React.createElement(get(activePanelItem, "panel", NoopComponent), {})}
+                        {React.createElement(get(activePanelItem, "panel", NoopComponent), {
+                          close: closeNonStandardPanel,
+                        })}
                       </Suspense>
                     </div>
                   </motion.div>

--- a/src/core/extensions/save-to-library.tsx
+++ b/src/core/extensions/save-to-library.tsx
@@ -3,7 +3,7 @@ import { ComponentType, useMemo } from "react";
 
 export type SaveToLibraryProps = {
   blockId: string;
-  blocks?: ChaiBlock[];
+  blocks: ChaiBlock[];
   close: () => void;
 };
 


### PR DESCRIPTION
This PR passes a close() prop to components registered with `registerSidebarPanel()`. THis should allow user to close the dialog programatically after performing certain actions. eg: submitting a form