### PR TITLE
fix: add unique keys to repeater blocks and only show loading state i…

### DIFF
--- a/src/render/blocks-renderer.tsx
+++ b/src/render/blocks-renderer.tsx
@@ -1,4 +1,4 @@
-import { filter, has, isArray, isEmpty, map, uniqBy } from "lodash-es";
+import { filter, get, has, isArray, isEmpty, map, uniqBy } from "lodash-es";
 import { RenderBlock } from "./block-renderer";
 import { RenderChaiBlocksProps } from "./render-chai-blocks";
 
@@ -18,17 +18,20 @@ export const RenderBlocks = (props: RenderChaiBlocksProps & { repeaterData?: { i
           return _type === "Repeater" ? (
             isArray(repeaterItems) &&
               repeaterItems.map((_, index) => (
-                <>
-                  <RenderBlocks
-                    {...props}
-                    parent={block._id}
-                    key={`${block._id}-${index}`}
-                    repeaterData={{ index, dataKey: $repeaterItemsKey }}
-                  />
-                </>
+                <RenderBlocks
+                  {...props}
+                  parent={block._id}
+                  key={`${get(block, "_parent", "root")}-${block._id}-${index}`}
+                  repeaterData={{ index, dataKey: $repeaterItemsKey }}
+                />
               ))
           ) : hasChildren(_id) ? (
-            <RenderBlocks {...props} parent={block._id} repeaterData={repeaterData} />
+            <RenderBlocks
+              {...props}
+              parent={block._id}
+              key={`${get(block, "_parent", "root")}-${block._id}`}
+              repeaterData={repeaterData}
+            />
           ) : null;
         }}
       </RenderBlock>

--- a/src/web-blocks/repeater.tsx
+++ b/src/web-blocks/repeater.tsx
@@ -29,7 +29,7 @@ export const Repeater = (props: ChaiBlockComponentProps<RepeaterProps>) => {
   return React.createElement(
     tag,
     { ...blockProps, ...styles },
-    $loading
+    $loading && inBuilder
       ? Array.from({ length: 2 }).map((_, i) => (
           <div key={i} className="animate-pulse rounded-md bg-primary/10 p-5">
             <div className="h-6 w-1/2 rounded-md bg-primary/10"></div>


### PR DESCRIPTION
…n builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the uniqueness of rendered block keys to prevent potential rendering issues.
  - Loading placeholders in repeaters now only appear when both loading and within the builder environment, reducing unnecessary loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->