### PR TITLE
feat: add loading skeleton and none tag option to repeater component

### DIFF
--- a/src/web-blocks/repeater.tsx
+++ b/src/web-blocks/repeater.tsx
@@ -26,6 +26,17 @@ export const Repeater = (props: ChaiBlockComponentProps<RepeaterProps>) => {
       </div>
     );
   }
+
+  if (tag === "none") {
+    return $loading && inBuilder
+      ? Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="animate-pulse rounded-md bg-primary/10 p-5">
+            <div className="h-6 w-1/2 rounded-md bg-primary/10"></div>
+            <div className="mt-2 h-4 w-1/2 rounded-md bg-primary/10"></div>
+          </div>
+        ))
+      : items;
+  }
   return React.createElement(
     tag,
     { ...blockProps, ...styles },
@@ -77,7 +88,7 @@ export const RepeaterConfig: Omit<ChaiBlockDefinition, "component"> = {
         title: "Tag",
         type: "string",
         default: "ul",
-        enum: ["div", "ul", "ol"],
+        enum: ["none", "div", "ul", "ol"],
       },
       limit: {
         title: "Limit",


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a loading skeleton and a "none" tag option to the Repeater component in the web-blocks directory.

### Why are these changes being made?

The "none" tag allows users to render items conditionally without a wrapper element, which is useful in certain scenarios. The loading skeleton is added to improve the user experience by providing visual feedback when content is loading in the builder environment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->