### PR TITLE
feat: add double-click navigation to partial blocks with overlay UI

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -20,6 +20,9 @@ function ChaiBuilderDefault() {
 
   return (
     <ChaiBuilderEditor
+      gotoPage={(args) => {
+        console.log("gotoPage", args);
+      }}
       permissions={null}
       // permissions={[]}
       pageExternalData={EXTERNAL_DATA}

--- a/src/core/components/canvas/IframeInitialContent.ts
+++ b/src/core/components/canvas/IframeInitialContent.ts
@@ -37,6 +37,8 @@ export const IframeInitialContent: string = `<!doctype html>
     [data-drop="yes"] { outline: 2px dashed orange !important; outline-offset: -2px }
     [data-dnd="yes"] { pointer-events: auto !important}
     [data-dnd="no"],[data-block-type="GlobalBlock"],[data-block-type="PartialBlock"] > * { pointer-events: none !important; }
+    [data-block-type="GlobalBlock"],[data-block-type="PartialBlock"] { position: relative !important; }
+    .partial-overlay { pointer-events: auto !important; }
     [data-dnd-dragged="yes"] { opacity: 0.6; pointer-events: none; }
     [data-dnd-dragged="no"] { opacity: 1; pointer-events: auto !important; }
     [force-show] { display: block !important; }

--- a/src/types/chaibuilder-editor-props.ts
+++ b/src/types/chaibuilder-editor-props.ts
@@ -106,6 +106,11 @@ export type ChaiThemeValues = {
 
 export interface ChaiBuilderEditorProps {
   /**
+   * Goto page callback
+   */
+  gotoPage?: ({ pageId, lang }: { pageId: string; lang: string }) => void;
+
+  /**
    * User
    */
   user?: {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add double-click navigation to partial blocks with overlay UI and update related components and props.

### Why are these changes being made?
This change allows users to easily navigate to and edit partial blocks within the editor by double-clicking on them, provided there are no unsaved changes. This improves the user experience by introducing an intuitive interaction method for accessing partial block details, and the overlay UI provides visual feedback. The modifications ensure that navigation respects the current language settings and only proceeds with saved content, reducing errors and enhancing usability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->