### PR TITLE
bug: Block copy was being triggered even when only text was selected, causing unexpected behavior on Ctrl+C / Cmd+C.

### DIFF
--- a/src/core/hooks/use-copy-blockIds.ts
+++ b/src/core/hooks/use-copy-blockIds.ts
@@ -41,6 +41,7 @@ export const useCopyBlocks = (): [
   const copyBlocks = useCallback(
     async (blockIds: Array<string>, clonePartialBlocks: boolean = false) => {
       try {
+        if (isEmpty(blockIds)) return;
         setIds(blockIds);
         resetCutBlockIds([]);
 
@@ -88,7 +89,7 @@ export const useCopyBlocks = (): [
         console.error("Failed to copy blocks to clipboard:", error);
       }
     },
-    [setIds, resetCutBlockIds],
+    [setIds, resetCutBlockIds, presentBlocks],
   );
 
   return [ids as string[], copyBlocks, hasPartialBlocks];

--- a/src/core/hooks/use-key-event-watcher.ts
+++ b/src/core/hooks/use-key-event-watcher.ts
@@ -4,7 +4,7 @@ import { useDuplicateBlocks } from "@/core/hooks/use-duplicate-blocks";
 import { usePasteBlocks } from "@/core/hooks/use-paste-blocks";
 import { useRemoveBlocks } from "@/core/hooks/use-remove-blocks";
 import { useSelectedBlock, useSelectedBlockIds } from "@/core/hooks/use-selected-blockIds";
-import { get } from "lodash-es";
+import { get, isEmpty } from "lodash-es";
 import { useHotkeys } from "react-hotkeys-hook";
 
 export const useKeyEventWatcher = (doc?: Document) => {
@@ -21,7 +21,12 @@ export const useKeyEventWatcher = (doc?: Document) => {
   useHotkeys("ctrl+z,command+z", () => undo(), {}, [undo]);
   useHotkeys("ctrl+y,command+y", () => redo(), {}, [redo]);
   useHotkeys("ctrl+x,command+x", () => setCutBlockIds(ids), {}, [ids, setCutBlockIds]);
-  useHotkeys("ctrl+c,command+c", () => setCopyBlockIds(ids), {}, [ids, setCopyBlockIds]);
+  useHotkeys(
+    "ctrl+c,command+c",
+    () => setCopyBlockIds(ids),
+    { ...options,  enabled: !isEmpty(ids), preventDefault: true },
+    [ids, setCopyBlockIds],
+  );
   useHotkeys(
     "ctrl+v,command+v",
     () => {
@@ -29,12 +34,12 @@ export const useKeyEventWatcher = (doc?: Document) => {
         pasteBlocks(ids);
       }
     },
-    { ...options, preventDefault: true },
+    { ...options, enabled: !isEmpty(ids), preventDefault: true },
     [ids, canPaste, pasteBlocks],
   );
 
   useHotkeys("esc", () => setIds([]), options, [setIds]);
-  useHotkeys("ctrl+d,command+d", () => duplicateBlocks(ids), { ...options, preventDefault: true }, [
+  useHotkeys("ctrl+d,command+d", () => duplicateBlocks(ids), { ...options, enabled: !isEmpty(ids), preventDefault: true }, [
     ids,
     duplicateBlocks,
   ]);


### PR DESCRIPTION
🐞 Issue
Block copy was being triggered even when only text was selected, causing unexpected behavior on Ctrl+C / Cmd+C.

✅ Fix
Enabled hotkeys (copy, paste, duplicate) only when block IDs are present.

Added missing callback dependencies to ensure stable references in useHotkeys.

Now, text selection and copy work normally, and block actions trigger only when intended.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Prevent the block copy action from being triggered during a text selection by checking for empty block IDs and updating the keyboard shortcut handler to disable when no blocks are selected.

### Why are these changes being made?

Previously, pressing Ctrl+C/Cmd+C initiated the block copy functionality even when only text was selected, causing confusion and unexpected behavior. The change ensures the event listener only activates when there are block IDs to copy, thus enhancing user experience and preventing erroneous actions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->