### PR TITLE
fix: display message for no settings available in PartialBlock selection

### DIFF
--- a/src/core/components/layout/root-layout.tsx
+++ b/src/core/components/layout/root-layout.tsx
@@ -10,7 +10,7 @@ import ThemeConfigPanel from "@/core/components/sidepanels/panels/theme-configur
 import { CHAI_BUILDER_EVENTS } from "@/core/events";
 import { useChaiSidebarPanels } from "@/core/extensions/sidebar-panels";
 import { useTopBarComponent } from "@/core/extensions/top-bar";
-import { useBuilderProp, useSidebarActivePanel } from "@/core/hooks";
+import { useBuilderProp, useSelectedBlock, useSidebarActivePanel } from "@/core/hooks";
 import { usePubSub } from "@/core/hooks/use-pub-sub";
 import { useRightPanel } from "@/core/hooks/use-theme";
 import { isDevelopment } from "@/core/import-html/general";
@@ -99,6 +99,8 @@ const RootLayout: ComponentType = () => {
   const [activePanel, setActivePanel] = useSidebarActivePanel();
   const lastStandardPanelRef = useRef<string | null>("outline"); // Default to "outline"
   const [lastStandardPanelWidth, setLastStandardPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
+  const selectedBlock = useSelectedBlock();
+  const isPartialBlock = selectedBlock?._type === "PartialBlock";
 
   const [panel, setRightPanel] = useRightPanel();
 
@@ -261,8 +263,8 @@ const RootLayout: ComponentType = () => {
             <motion.div
               id="right-panel"
               className="h-full max-h-full border-l border-border"
-              initial={{ width: activePanel === "ai" ? 0 : DEFAULT_PANEL_WIDTH }}
-              animate={{ width: activePanel === "ai" ? 0 : DEFAULT_PANEL_WIDTH }}
+              initial={{ width: activePanel === "ai" || isPartialBlock ? 0 : DEFAULT_PANEL_WIDTH }}
+              animate={{ width: activePanel === "ai" || isPartialBlock ? 0 : DEFAULT_PANEL_WIDTH }}
               transition={{ duration: 0.3, ease: "easeInOut" }}>
               <div className="no-scrollbar overflow h-full max-h-full overflow-hidden">
                 <div className="flex h-full max-h-full flex-col overflow-hidden p-3">

--- a/src/core/components/settings/settings-panel.tsx
+++ b/src/core/components/settings/settings-panel.tsx
@@ -42,7 +42,6 @@ const SettingsPanel: React.FC = () => {
 
   let isSettingsDisabled = !hasPermission(PERMISSIONS.EDIT_BLOCK);
   const isStylesDisabled = !hasPermission(PERMISSIONS.EDIT_STYLES);
-  const isPartialBlock = selectedBlock?._type === "PartialBlock";
   if (isNull(selectedBlock)) {
     return (
       <div className="p-4 text-center">
@@ -91,18 +90,6 @@ const SettingsPanel: React.FC = () => {
           <br />
         </div>
       </ErrorBoundary>
-    );
-  }
-  
-  // Show no settings available for the selected Partial block.
-  if (isPartialBlock) {
-    return (
-      <div className="p-4 text-center">
-        <div className="space-y-4 rounded-xl p-4 text-muted-foreground">
-          <MixerHorizontalIcon className="mx-auto text-3xl" />
-          <h1>{t("No settings available for the selected block.")}</h1>
-        </div>
-      </div>
     );
   }
 


### PR DESCRIPTION
This PR adds a user-friendly message when a PartialBlock is selected, indicating that no settings are available for this block type.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a user-friendly message to the settings panel to indicate when no settings are available for the selected PartialBlock.

### Why are these changes being made?

This change improves the user experience by clearly communicating that no settings are available for PartialBlock components, preventing confusion when interacting with the settings panel. Previously, users might not understand why settings do not appear, and this approach directly addresses that potential issue by providing immediate visual feedback.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->