### PR TITLE
Relocated the Reset All Style Button 

### DIFF
--- a/src/core/components/settings/block-styling-props.tsx
+++ b/src/core/components/settings/block-styling-props.tsx
@@ -1,6 +1,5 @@
 import { useSelectedBlock, useSelectedStylingBlocks, useTranslation } from "@/core/hooks";
 import { useResetBlockStyles } from "@/core/hooks/use-reset-block-styles";
-import { Button } from "@/ui";
 import { Badge } from "@/ui/shadcn/components/ui/badge";
 import {
   DropdownMenu,
@@ -8,7 +7,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/ui/shadcn/components/ui/dropdown-menu";
-import { ResetIcon } from "@radix-ui/react-icons";
 import { find, isEmpty, map, startCase } from "lodash-es";
 import { MoreVertical } from "lucide-react";
 
@@ -21,14 +19,8 @@ export const BlockStylingProps = () => {
   const stylesProps = Object.keys(selectedBlock).filter(
     (prop) => typeof selectedBlock[prop] === "string" && selectedBlock[prop].startsWith("#styles:"),
   );
-  const { reset, resetAll } = useResetBlockStyles();
+  const { reset } = useResetBlockStyles();
   const hasStyles = !isEmpty(stylesProps) && stylesProps.length > 1;
-  const resetButton = (
-    <Button className="h-6 w-full" variant="outline" size="sm" onClick={() => resetAll()}>
-      <ResetIcon />
-      {t("Reset styles")}
-    </Button>
-  );
 
   const isSelected = (prop: string) => {
     return find(stylingBlocks, (block) => block.prop === prop);
@@ -36,7 +28,6 @@ export const BlockStylingProps = () => {
 
   return (
     <>
-      {resetButton}
       {hasStyles && (
         <div className="flex flex-wrap gap-1">
           <label htmlFor="block-styling-props" className="py-1 text-xs">

--- a/src/core/components/settings/choices/reset-all-styles.tsx
+++ b/src/core/components/settings/choices/reset-all-styles.tsx
@@ -15,7 +15,7 @@ export const ResetStylesButton = () => {
           type="button"
           className="ml-1 rounded-sm p-0.5 hover:bg-blue-300 hover:text-blue-600"
           onClick={(e) => e.stopPropagation()}>
-          <MoreVertical className="h-4 w-4" />
+          <MoreVertical className="h-3 w-3" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" className="border-border text-xs">
@@ -24,7 +24,7 @@ export const ResetStylesButton = () => {
           onClick={() => {
             resetAll();
           }}>
-          <ResetIcon className="h-4 w-4" />
+          <ResetIcon className="h-3 w-3" />
           {t("Reset styles")}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/core/components/settings/choices/reset-all-styles.tsx
+++ b/src/core/components/settings/choices/reset-all-styles.tsx
@@ -1,0 +1,33 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/shadcn/components/ui/dropdown-menu";
+import { MoreVertical } from "lucide-react";
+import { ResetIcon } from "@radix-ui/react-icons";
+import { useResetBlockStyles } from "@/core/hooks";
+import { useTranslation } from "react-i18next";
+
+export const ResetStylesButton = () => {
+  const { resetAll } = useResetBlockStyles();
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="ml-1 rounded-sm p-0.5 hover:bg-blue-300 hover:text-blue-600"
+          onClick={(e) => e.stopPropagation()}>
+          <MoreVertical className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" className="border-border text-xs">
+        <DropdownMenuItem
+          className="flex items-center gap-1 text-xs"
+          onClick={() => {
+            resetAll();
+          }}>
+          <ResetIcon className="h-4 w-4" />
+          {t("Reset styles")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/core/components/settings/settings-panel.tsx
+++ b/src/core/components/settings/settings-panel.tsx
@@ -2,21 +2,16 @@ import { FallbackError } from "@/core/components/fallback-error";
 import BlockSettings from "@/core/components/settings/block-settings";
 import BlockStyling from "@/core/components/settings/block-styling";
 import { BlockAttributesEditor } from "@/core/components/settings/new-panel/block-attributes-editor";
-import { useBuilderProp, useResetBlockStyles, useSelectedBlock, useSelectedStylingBlocks } from "@/core/hooks";
+import { useBuilderProp, useSelectedBlock, useSelectedStylingBlocks } from "@/core/hooks";
 import { PERMISSIONS, usePermissions } from "@/core/main";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/ui/shadcn/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/shadcn/components/ui/tabs";
-import { MixerHorizontalIcon, ResetIcon } from "@radix-ui/react-icons";
+import { MixerHorizontalIcon } from "@radix-ui/react-icons";
 import { isEmpty, isNull, noop } from "lodash-es";
-import { ChevronDown, MoreVertical } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import React, { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
+import { ResetStylesButton } from "./choices/reset-all-styles";
 
 function BlockAttributesToggle() {
   const { t } = useTranslation();
@@ -45,32 +40,6 @@ const SettingsPanel: React.FC = () => {
   const { t } = useTranslation();
   const onErrorFn = useBuilderProp("onError", noop);
   const { hasPermission } = usePermissions();
-  const { resetAll } = useResetBlockStyles();
-
-  const resetButton = (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="ml-1 rounded-sm p-0.5 hover:bg-blue-300 hover:text-blue-600"
-          onClick={(e) => e.stopPropagation()}>
-          <MoreVertical className="h-4 w-4" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent side="bottom" className="border-border text-xs">
-        <DropdownMenuItem
-          className="flex items-center gap-1 text-xs"
-          onClick={() => {
-            resetAll();
-
-          }}>
-          <ResetIcon className="h-4 w-4" />
-          {t("Reset styles")}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-
   let isSettingsDisabled = !hasPermission(PERMISSIONS.EDIT_BLOCK);
   const isStylesDisabled = !hasPermission(PERMISSIONS.EDIT_STYLES);
 
@@ -115,8 +84,8 @@ const SettingsPanel: React.FC = () => {
     return (
       <ErrorBoundary fallback={<FallbackError />} onError={onErrorFn}>
         <div className="no-scrollbar h-full max-h-min w-full overflow-y-auto overflow-x-hidden">
-          <div className="flex items-center w-full justify-end">
-            {resetButton}
+          <div className="flex w-full items-center justify-end">
+            <ResetStylesButton />
           </div>
           <BlockStyling />
           <BlockAttributesToggle />
@@ -132,16 +101,16 @@ const SettingsPanel: React.FC = () => {
   return (
     <ErrorBoundary fallback={<FallbackError />} onError={onErrorFn}>
       <Tabs defaultValue="settings" className="flex flex-1 flex-col">
-        <div className="flex justify-between items-center">
-        <TabsList className="grid h-auto w-full grid-cols-2 p-1 py-1">
-          <TabsTrigger value="settings" className="text-xs">
-            Settings
-          </TabsTrigger>
-          <TabsTrigger value="styles" className="text-xs">
-            Styles
-          </TabsTrigger>
-        </TabsList>
-        {resetButton}
+        <div className="flex items-center justify-between">
+          <TabsList className="grid h-auto w-full grid-cols-2 p-1 py-1">
+            <TabsTrigger value="settings" className="text-xs">
+              Settings
+            </TabsTrigger>
+            <TabsTrigger value="styles" className="text-xs">
+              Styles
+            </TabsTrigger>
+          </TabsList>
+          <ResetStylesButton />
         </div>
         <TabsContent value="settings" className="no-scrollbar h-full max-h-min overflow-y-auto">
           <BlockSettings />

--- a/src/core/components/settings/settings-panel.tsx
+++ b/src/core/components/settings/settings-panel.tsx
@@ -106,11 +106,11 @@ const SettingsPanel: React.FC = () => {
             <TabsTrigger value="settings" className="text-xs">
               Settings
             </TabsTrigger>
-            <TabsTrigger value="styles" className="text-xs">
+            <TabsTrigger value="styles" className="flex items-center justify-between text-xs">
               Styles
+              <ResetStylesButton />
             </TabsTrigger>
           </TabsList>
-          <ResetStylesButton />
         </div>
         <TabsContent value="settings" className="no-scrollbar h-full max-h-min overflow-y-auto">
           <BlockSettings />

--- a/src/core/components/settings/settings-panel.tsx
+++ b/src/core/components/settings/settings-panel.tsx
@@ -2,12 +2,18 @@ import { FallbackError } from "@/core/components/fallback-error";
 import BlockSettings from "@/core/components/settings/block-settings";
 import BlockStyling from "@/core/components/settings/block-styling";
 import { BlockAttributesEditor } from "@/core/components/settings/new-panel/block-attributes-editor";
-import { useBuilderProp, useSelectedBlock, useSelectedStylingBlocks } from "@/core/hooks";
+import { useBuilderProp, useResetBlockStyles, useSelectedBlock, useSelectedStylingBlocks } from "@/core/hooks";
 import { PERMISSIONS, usePermissions } from "@/core/main";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/ui/shadcn/components/ui/dropdown-menu";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/ui/shadcn/components/ui/tabs";
-import { MixerHorizontalIcon } from "@radix-ui/react-icons";
+import { MixerHorizontalIcon, ResetIcon } from "@radix-ui/react-icons";
 import { isEmpty, isNull, noop } from "lodash-es";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, MoreVertical } from "lucide-react";
 import React, { useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useTranslation } from "react-i18next";
@@ -39,6 +45,31 @@ const SettingsPanel: React.FC = () => {
   const { t } = useTranslation();
   const onErrorFn = useBuilderProp("onError", noop);
   const { hasPermission } = usePermissions();
+  const { resetAll } = useResetBlockStyles();
+
+  const resetButton = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="ml-1 rounded-sm p-0.5 hover:bg-blue-300 hover:text-blue-600"
+          onClick={(e) => e.stopPropagation()}>
+          <MoreVertical className="h-4 w-4" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="bottom" className="border-border text-xs">
+        <DropdownMenuItem
+          className="flex items-center gap-1 text-xs"
+          onClick={() => {
+            resetAll();
+
+          }}>
+          <ResetIcon className="h-4 w-4" />
+          {t("Reset styles")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 
   let isSettingsDisabled = !hasPermission(PERMISSIONS.EDIT_BLOCK);
   const isStylesDisabled = !hasPermission(PERMISSIONS.EDIT_STYLES);
@@ -84,6 +115,9 @@ const SettingsPanel: React.FC = () => {
     return (
       <ErrorBoundary fallback={<FallbackError />} onError={onErrorFn}>
         <div className="no-scrollbar h-full max-h-min w-full overflow-y-auto overflow-x-hidden">
+          <div className="flex items-center w-full justify-end">
+            {resetButton}
+          </div>
           <BlockStyling />
           <BlockAttributesToggle />
           <br />
@@ -98,6 +132,7 @@ const SettingsPanel: React.FC = () => {
   return (
     <ErrorBoundary fallback={<FallbackError />} onError={onErrorFn}>
       <Tabs defaultValue="settings" className="flex flex-1 flex-col">
+        <div className="flex justify-between items-center">
         <TabsList className="grid h-auto w-full grid-cols-2 p-1 py-1">
           <TabsTrigger value="settings" className="text-xs">
             Settings
@@ -106,6 +141,8 @@ const SettingsPanel: React.FC = () => {
             Styles
           </TabsTrigger>
         </TabsList>
+        {resetButton}
+        </div>
         <TabsContent value="settings" className="no-scrollbar h-full max-h-min overflow-y-auto">
           <BlockSettings />
           <br />


### PR DESCRIPTION
![Screenshot from 2025-07-02 11-38-45](https://github.com/user-attachments/assets/e6a0eb86-0947-4aca-9ea9-e979c26f137d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Reset styles" button in the settings panel, allowing users to reset all block styles from a dropdown menu.

* **Refactor**
  * Updated the settings interface to reposition the reset styles functionality for improved accessibility and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->