### PR TITLE
feat: display custom tag names in outline panel for Box components

### DIFF
--- a/src/core/components/sidepanels/panels/outline/getBlockDisplayName.test.ts
+++ b/src/core/components/sidepanels/panels/outline/getBlockDisplayName.test.ts
@@ -1,0 +1,37 @@
+import { getBlockDisplayName } from './node';
+
+describe('getBlockDisplayName', () => {
+  it('should return the _name when it exists', () => {
+    const data = { _name: 'My Block', _type: 'Box', tag: 'section' };
+    expect(getBlockDisplayName(data)).toBe('My Block');
+  });
+
+  it('should return the formatted tag name for Box type when tag is not div', () => {
+    const data = { _type: 'Box', tag: 'section' };
+    expect(getBlockDisplayName(data)).toBe('Section');
+  });
+
+  it('should not return tag name for Box type when tag is div', () => {
+    const data = { _type: 'Box', tag: 'div' };
+    expect(getBlockDisplayName(data)).toBe('Box');
+  });
+
+  it('should return the type name when no _name or special handling is needed', () => {
+    const data = { _type: 'Custom/Button' };
+    expect(getBlockDisplayName(data)).toBe('Button');
+  });
+
+  it('should handle Box type with no tag', () => {
+    const data = { _type: 'Box' };
+    expect(getBlockDisplayName(data)).toBe('Box');
+  });
+
+  it('should handle empty data object', () => {
+    expect(getBlockDisplayName({})).toBe('');
+  });
+
+  it('should handle null or undefined input', () => {
+    expect(getBlockDisplayName(null as any)).toBe('');
+    expect(getBlockDisplayName(undefined as any)).toBe('');
+  });
+});

--- a/src/core/components/sidepanels/panels/outline/node.tsx
+++ b/src/core/components/sidepanels/panels/outline/node.tsx
@@ -36,6 +36,15 @@ const Input = ({ node }) => {
 };
 
 const currentAddSelection = atom<any>(null);
+
+export const getBlockDisplayName = (data: any): string => {
+  if (data?._name) return data._name;
+  if (data?._type === "Box" && data?.tag && data?.tag !== "div") {
+    return startCase(data.tag);
+  }
+  return data?._type?.split("/").pop() || "";
+};
+
 export const Node = memo(({ node, style, dragHandle }: NodeRendererProps<any>) => {
   const { t } = useTranslation();
   const [hiddenBlocks, , toggleHidden] = useHiddenBlockIds();
@@ -172,13 +181,6 @@ export const Node = memo(({ node, style, dragHandle }: NodeRendererProps<any>) =
     );
   }, [data, hasPermission]);
 
-  const getBlockDisplayName = (data: any): string => {
-    if (data?._name) return data._name;
-    if (data?._type === "Box" && data?.tag && data?.tag !== "div") {
-      return startCase(data.tag);
-    }
-    return data?._type?.split("/").pop() || "";
-  };
 
   return (
     <div className="w-full">

--- a/src/core/components/sidepanels/panels/outline/node.tsx
+++ b/src/core/components/sidepanels/panels/outline/node.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/core/utils/cn";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/shadcn/components/ui/tooltip";
 import { PlusIcon } from "@radix-ui/react-icons";
 import { atom, useAtom } from "jotai";
-import { get, has, isEmpty } from "lodash-es";
+import { get, has, isEmpty, startCase } from "lodash-es";
 import { ChevronRight, EyeOffIcon, MoreVertical } from "lucide-react";
 import { memo, useEffect, useMemo } from "react";
 import { NodeRendererProps } from "react-arborist";
@@ -252,7 +252,12 @@ export const Node = memo(({ node, style, dragHandle }: NodeRendererProps<any>) =
                     node.edit();
                     node.deselect();
                   }}>
-                  <span>{data?._name || data?._type.split("/").pop()}</span>
+                  <span>
+                    {data?._name ||
+                      (data?._type === "Box" && data?.tag && data?.tag !== "div"
+                        ? startCase(data.tag)
+                        : data?._type.split("/").pop())}
+                  </span>
                 </div>
               )}
             </div>

--- a/src/core/components/sidepanels/panels/outline/node.tsx
+++ b/src/core/components/sidepanels/panels/outline/node.tsx
@@ -172,6 +172,14 @@ export const Node = memo(({ node, style, dragHandle }: NodeRendererProps<any>) =
     );
   }, [data, hasPermission]);
 
+  const getBlockDisplayName = (data: any): string => {
+    if (data?._name) return data._name;
+    if (data?._type === "Box" && data?.tag && data?.tag !== "div") {
+      return startCase(data.tag);
+    }
+    return data?._type?.split("/").pop() || "";
+  };
+
   return (
     <div className="w-full">
       <div
@@ -252,12 +260,7 @@ export const Node = memo(({ node, style, dragHandle }: NodeRendererProps<any>) =
                     node.edit();
                     node.deselect();
                   }}>
-                  <span>
-                    {data?._name ||
-                      (data?._type === "Box" && data?.tag && data?.tag !== "div"
-                        ? startCase(data.tag)
-                        : data?._type.split("/").pop())}
-                  </span>
+                  <span>{getBlockDisplayName(data)}</span>
                 </div>
               )}
             </div>


### PR DESCRIPTION
[Screencast from 2025-07-22 12-17-59.webm](https://github.com/user-attachments/assets/b17e75f7-f9c3-4c2a-a08b-a2cbd650edaa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved outline panel labels for "Box" nodes by displaying a human-readable tag name when applicable.  
  * Enhanced node labeling to provide clearer and more consistent display names across various node types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->