### PR TITLE
Amitdhiman5086/chai 912 ability to delete all classes move delete to left instead of

### DIFF
--- a/src/core/components/settings/block-styling-props.tsx
+++ b/src/core/components/settings/block-styling-props.tsx
@@ -1,4 +1,10 @@
-import { useSelectedBlock, useSelectedStylingBlocks, useTranslation } from "@/core/hooks";
+import {
+  useSelectedBlock,
+  useSelectedStylingBlocks,
+  useTranslation,
+  useRemoveClassesFromBlocks,
+  useSelectedBlockIds,
+} from "@/core/hooks";
 import { useResetBlockStyles } from "@/core/hooks/use-reset-block-styles";
 import { Badge } from "@/ui/shadcn/components/ui/badge";
 import {
@@ -7,12 +13,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/ui/shadcn/components/ui/dropdown-menu";
-import { find, isEmpty, map, startCase } from "lodash-es";
+import { find, get, isEmpty, map, startCase } from "lodash-es";
 import { MoreVertical } from "lucide-react";
+import { getSplitChaiClasses } from "@/core/hooks/get-split-classes";
 
 export const BlockStylingProps = () => {
   const selectedBlock = useSelectedBlock();
   const [stylingBlocks, setStylingBlocks] = useSelectedStylingBlocks();
+  const removeClassesFromBlocks = useRemoveClassesFromBlocks();
+  const [selectedIds] = useSelectedBlockIds();
   const { t } = useTranslation();
   if (!selectedBlock) return null;
   // find all styles props of selected block by checking for value of each prop as string and starts with #styles:
@@ -21,6 +30,9 @@ export const BlockStylingProps = () => {
   );
   const { reset } = useResetBlockStyles();
   const hasStyles = !isEmpty(stylesProps) && stylesProps.length > 1;
+  const prop = get(selectedBlock, stylingBlocks[0].prop, "");
+  const { classes : classesString } = getSplitChaiClasses(prop);
+  const classes = classesString.split(" ").filter((cls) => !isEmpty(cls));
 
   const isSelected = (prop: string) => {
     return find(stylingBlocks, (block) => block.prop === prop);
@@ -61,6 +73,13 @@ export const BlockStylingProps = () => {
                             reset(prop);
                           }}>
                           {t("Reset style")}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-xs"
+                          onClick={() => {
+                            removeClassesFromBlocks(selectedIds, classes, true);
+                          }}>
+                          {t("Clear styles")}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/src/core/components/settings/block-styling-props.tsx
+++ b/src/core/components/settings/block-styling-props.tsx
@@ -30,9 +30,9 @@ export const BlockStylingProps = () => {
   );
   const { reset } = useResetBlockStyles();
   const hasStyles = !isEmpty(stylesProps) && stylesProps.length > 1;
-  const prop = get(selectedBlock, stylingBlocks[0].prop, "");
-  const { classes : classesString } = getSplitChaiClasses(prop);
-  const classes = classesString.split(" ").filter((cls) => !isEmpty(cls));
+  const prop = get(selectedBlock, stylingBlocks[0]?.prop, "");
+  const { classes: classesString = "" } = getSplitChaiClasses(prop) || {};
+  const classes = classesString ? classesString.split(" ").filter((cls) => !isEmpty(cls)) : [];
 
   const isSelected = (prop: string) => {
     return find(stylingBlocks, (block) => block.prop === prop);

--- a/src/core/components/settings/choices/reset-all-styles.tsx
+++ b/src/core/components/settings/choices/reset-all-styles.tsx
@@ -1,20 +1,35 @@
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/ui/shadcn/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/ui/shadcn/components/ui/dropdown-menu";
 import { MoreVertical } from "lucide-react";
-import { ResetIcon } from "@radix-ui/react-icons";
-import { useResetBlockStyles } from "@/core/hooks";
+import { Cross2Icon, ResetIcon } from "@radix-ui/react-icons";
+import {
+  useRemoveAllClassesForBlock,
+  useResetBlockStyles,
+  useSelectedBlock,
+  useSelectedStylingBlocks,
+} from "@/core/hooks";
 import { useTranslation } from "react-i18next";
+import { isEmpty } from "lodash-es";
 
 export const ResetStylesButton = () => {
   const { resetAll } = useResetBlockStyles();
+  const selectedBlock = useSelectedBlock();
+  const [stylingBlocks] = useSelectedStylingBlocks();
+  const removeAllClasses = useRemoveAllClassesForBlock();
   const { t } = useTranslation();
+
+  if (!selectedBlock || isEmpty(stylingBlocks)) {
+    return null;
+  }
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className=" p-0.5 rounded-sm hover:bg-gray-300"
-          onClick={(e) => e.stopPropagation()}>
+        <button type="button" className="rounded-sm p-0.5 hover:bg-gray-300" onClick={(e) => e.stopPropagation()}>
           <MoreVertical className="h-3 w-3" />
         </button>
       </DropdownMenuTrigger>
@@ -26,6 +41,16 @@ export const ResetStylesButton = () => {
           }}>
           <ResetIcon className="h-3 w-3" />
           {t("Reset styles")}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="text-xs"
+          onClick={() => {
+            if (selectedBlock) {
+              removeAllClasses(selectedBlock, true);
+            }
+          }}>
+          <Cross2Icon className="h-3 w-3" />
+          {t("Clear styles")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/core/components/settings/choices/reset-all-styles.tsx
+++ b/src/core/components/settings/choices/reset-all-styles.tsx
@@ -29,9 +29,9 @@ export const ResetStylesButton = () => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button type="button" className="rounded-sm p-0.5 hover:bg-gray-300" onClick={(e) => e.stopPropagation()}>
+        <div className="inline-flex rounded-sm p-0.5 hover:bg-gray-300" onClick={(e) => e.stopPropagation()}>
           <MoreVertical className="h-3 w-3" />
-        </button>
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" className="border-border text-xs">
         <DropdownMenuItem

--- a/src/core/components/settings/new-panel/manual-classes.tsx
+++ b/src/core/components/settings/new-panel/manual-classes.tsx
@@ -215,7 +215,7 @@ export function ManualClasses() {
                     }
                   }, 10);
                 }}
-                className="flex cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px px-1.5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                className="flex cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px  px-1 text-[11px] text-gray-600 hover:border-gray-300 hover:pl-4 group-hover:pl-4 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
                 {cls}
                 <Cross2Icon
                   onClick={() => removeClassesFromBlocks(selectedIds, [cls], true)}

--- a/src/core/components/settings/new-panel/manual-classes.tsx
+++ b/src/core/components/settings/new-panel/manual-classes.tsx
@@ -215,12 +215,27 @@ export function ManualClasses() {
                     }
                   }, 10);
                 }}
-                className="flex cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px  px-1 text-[11px] text-gray-600 hover:border-gray-300 hover:pl-4 group-hover:pl-4 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                className="flex cursor-default items-center gap-x-1 truncate break-words border border-border bg-gray-200 p-px pl-5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 hover:pl-5 group-hover:pl-5 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
                 {cls}
                 <Cross2Icon
                   onClick={() => removeClassesFromBlocks(selectedIds, [cls], true)}
-                  className="absolute left-1 mr-0.5 hidden h-3 w-3 rounded-full bg-red-400 text-white hover:bg-red-500 hover:text-white group-hover:block"
+                  className="absolute left-0.5 mr-0.5 hidden group-hover:block h-4 w-4 bg-gray-500 font-bold group-hover:bg-gray-300 group-hover:text-red-500 "
                 />
+                <svg
+                  className="absolute left-0.5 mr-0.5 group-hover:hidden h-4 w-4 "
+                  fill="#9ca19d"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  xmlSpace="preserve">
+                  <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
+                  <g id="SVGRepo_tracerCarrier" strokeLinecap="round" strokeLinejoin="round"></g>
+                  <g id="SVGRepo_iconCarrier">
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M12 6.036c-2.667 0-4.333 1.325-5 3.976 1-1.325 2.167-1.822 3.5-1.491.761.189 1.305.738 1.906 1.345C13.387 10.855 14.522 12 17 12c2.667 0 4.333-1.325 5-3.976-1 1.325-2.166 1.822-3.5 1.491-.761-.189-1.305-.738-1.907-1.345-.98-.99-2.114-2.134-4.593-2.134zM7 12c-2.667 0-4.333 1.325-5 3.976 1-1.326 2.167-1.822 3.5-1.491.761.189 1.305.738 1.907 1.345.98.989 2.115 2.134 4.594 2.134 2.667 0 4.333-1.325 5-3.976-1 1.325-2.167 1.822-3.5 1.491-.761-.189-1.305-.738-1.906-1.345C10.613 13.145 9.478 12 7 12z"></path>
+                  </g>
+                </svg>
               </button>
             </div>
           ),

--- a/src/core/components/settings/new-panel/manual-classes.tsx
+++ b/src/core/components/settings/new-panel/manual-classes.tsx
@@ -205,12 +205,6 @@ export function ManualClasses() {
             />
           ) : (
             <div key={cls} className="group relative flex max-w-[260px] items-center">
-              {editingClass !== cls && (
-                <Cross2Icon
-                  onClick={() => removeClassesFromBlocks(selectedIds, [cls], true)}
-                  className="mr-1 h-3 w-3 rounded-full bg-red-400 text-white hover:bg-red-500 hover:text-white"
-                />
-              )}
               <button
                 onDoubleClick={() => {
                   setNewCls(cls);
@@ -223,6 +217,10 @@ export function ManualClasses() {
                 }}
                 className="flex cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px px-1.5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
                 {cls}
+                <Cross2Icon
+                  onClick={() => removeClassesFromBlocks(selectedIds, [cls], true)}
+                  className="absolute left-1 mr-0.5 hidden h-3 w-3 rounded-full bg-red-400 text-white hover:bg-red-500 hover:text-white group-hover:block"
+                />
               </button>
             </div>
           ),

--- a/src/core/components/settings/new-panel/manual-classes.tsx
+++ b/src/core/components/settings/new-panel/manual-classes.tsx
@@ -204,26 +204,27 @@ export function ManualClasses() {
               className="group relative flex max-w-[260px] cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px px-1.5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
             />
           ) : (
-            <button
-              key={cls}
-              onDoubleClick={() => {
-                setNewCls(cls);
-                removeClassesFromBlocks(selectedIds, [cls]);
-                setTimeout(() => {
-                  if (inputRef.current) {
-                    inputRef.current.focus();
-                  }
-                }, 10);
-              }}
-              className="group relative flex max-w-[260px] cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px px-1.5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-              {cls}
+            <div key={cls} className="group relative flex max-w-[260px] items-center">
               {editingClass !== cls && (
                 <Cross2Icon
                   onClick={() => removeClassesFromBlocks(selectedIds, [cls], true)}
-                  className="invisible absolute right-1 rounded-full bg-red-400 hover:text-white group-hover:visible group-hover:cursor-pointer"
+                  className="mr-1 h-3 w-3 rounded-full bg-red-400 text-white hover:bg-red-500 hover:text-white"
                 />
               )}
-            </button>
+              <button
+                onDoubleClick={() => {
+                  setNewCls(cls);
+                  removeClassesFromBlocks(selectedIds, [cls]);
+                  setTimeout(() => {
+                    if (inputRef.current) {
+                      inputRef.current.focus();
+                    }
+                  }, 10);
+                }}
+                className="flex cursor-default items-center gap-x-1 truncate break-words rounded border border-border bg-gray-200 p-px px-1.5 pr-2 text-[11px] text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                {cls}
+              </button>
+            </div>
           ),
         )}
       </div>

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -24,7 +24,7 @@ import { usePasteBlocks } from "@/core/hooks/use-paste-blocks";
 import { usePermissions } from "@/core/hooks/use-permissions";
 import { usePreviewMode } from "@/core/hooks/use-preview-mode";
 import { useRemoveBlocks } from "@/core/hooks/use-remove-blocks";
-import { useRemoveClassesFromBlocks } from "@/core/hooks/use-remove-classes-from-blocks";
+import { useRemoveAllClassesForBlock, useRemoveClassesFromBlocks } from "@/core/hooks/use-remove-classes-from-blocks";
 import { useResetBlockStyles } from "@/core/hooks/use-reset-block-styles";
 import { useSavePage } from "@/core/hooks/use-save-page";
 import { useSelectedBlockAllClasses, useSelectedBlockCurrentClasses } from "@/core/hooks/use-select-block-classes";
@@ -76,6 +76,7 @@ export {
   usePreviewMode,
   useRemoveBlocks,
   useRemoveClassesFromBlocks,
+  useRemoveAllClassesForBlock,
   useResetBlockStyles,
   useRightPanel,
   useSavePage,

--- a/src/core/hooks/use-remove-classes-from-blocks.ts
+++ b/src/core/hooks/use-remove-classes-from-blocks.ts
@@ -46,6 +46,36 @@ export const removeClassFromBlocksAtom: any = atom(null, (get, _set, { blockIds,
   });
 });
 
+export const removeAllClassesForBlock = (block: ChaiBlock): { ids: string[]; props: Record<string, string> } => {
+  const styleProps = Object.keys(block).filter(
+    (prop) => typeof block[prop] === "string" && (block[prop] as string).startsWith(STYLES_KEY),
+  );
+
+  const updatedProps: Record<string, string> = {};
+  
+  styleProps.forEach((prop) => {
+    updatedProps[prop] = `${STYLES_KEY},`;
+  });
+
+  return {
+    ids: [block._id],
+    props: updatedProps,
+  };
+};
+
+export const useRemoveAllClassesForBlock = () => {
+  const { updateBlocks, updateBlocksRuntime } = useBlocksStoreUndoableActions();
+  
+  return useCallback((block: ChaiBlock, undo = false) => {
+    const { ids, props } = removeAllClassesForBlock(block);
+    if (undo) {
+      updateBlocks(ids, props);
+    } else {
+      updateBlocksRuntime(ids, props);
+    }
+  }, [updateBlocks, updateBlocksRuntime]);
+};
+
 export const useRemoveClassesFromBlocks = (): Function => {
   const { updateBlocks, updateBlocksRuntime } = useBlocksStoreUndoableActions();
   const removeClassesFromBlocks = useSetAtom(removeClassFromBlocksAtom);


### PR DESCRIPTION
[Screencast from 2025-07-23 12-49-17.webm](https://github.com/user-attachments/assets/6d0b3fbc-65d1-48b5-91e3-cfe6e0e7470a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Clear styles" option to relevant dropdown menus, allowing users to quickly remove all CSS classes from selected blocks.
  * Enhanced style management by enabling complete clearing of styles from blocks through the UI.

* **Style**
  * Improved the layout and interaction for class management by repositioning the delete icon to the left, making it visible on hover, and separating delete and edit actions for better usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->