### PR TITLE
feat: add prop description as tooltip

### DIFF
--- a/src/core/components/settings/new-panel/manual-classes.tsx
+++ b/src/core/components/settings/new-panel/manual-classes.tsx
@@ -222,8 +222,8 @@ export function ManualClasses() {
                   className="absolute left-0.5 mr-0.5 hidden group-hover:block h-4 w-4 bg-gray-500 font-bold group-hover:bg-gray-300 group-hover:text-red-500 "
                 />
                 <svg
-                  className="absolute left-0.5 mr-0.5 group-hover:hidden h-4 w-4 "
-                  fill="#9ca19d"
+                  className="absolute left-0.5 mr-0.5 group-hover:hidden h-3.5 w-3.5 "
+                  fill="rgba(55, 65, 81, 0.4)"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
                   xmlSpace="preserve">

--- a/src/core/rjsf-widgets/json-form-field-template.tsx
+++ b/src/core/rjsf-widgets/json-form-field-template.tsx
@@ -2,10 +2,11 @@ import { usePageExternalData } from "@/core/atoms/builder";
 import { LANGUAGES } from "@/core/constants/LANGUAGES";
 import { useLanguages, useSelectedBlock } from "@/core/hooks";
 import { Badge } from "@/ui/shadcn/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/ui/shadcn/components/ui/tooltip";
 import { useRegisteredChaiBlocks } from "@chaibuilder/runtime";
 import { FieldTemplateProps } from "@rjsf/utils";
 import { get, isEmpty } from "lodash-es";
-import { ChevronDown, ChevronRight, List } from "lucide-react";
+import { ChevronDown, ChevronRight, Info, List } from "lucide-react";
 import { useMemo, useState } from "react";
 import { DataBindingSelector } from "./data-binding-selector";
 
@@ -84,10 +85,24 @@ const JSONFormFieldTemplate = ({
     <div className={classNames}>
       {schema.title && (
         <div className="flex items-center justify-between">
-          <label htmlFor={id} className={schema.type === "object" ? "pb-2" : ""}>
-            {label} {showLangSuffix && <small className="text-[9px] text-zinc-400"> {currentLanguage}</small>}
-            {required && schema.type !== "object" ? " *" : null}
-          </label>
+          <div className="flex items-center gap-2">
+            <label htmlFor={id} className={schema.type === "object" ? "pb-2" : ""}>
+              {label} {showLangSuffix && <small className="text-[9px] text-zinc-400"> {currentLanguage}</small>}
+              {required && schema.type !== "object" ? " *" : null}
+            </label>
+            {schema.description && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="h-3 w-3 text-muted-foreground/70" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                   {schema.description}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
           {!schema.enum && !schema.oneOf && pageExternalData && (
             <>
               <DataBindingSelector


### PR DESCRIPTION
[Screencast from 2025-07-23 16-05-53.webm](https://github.com/user-attachments/assets/46980fe8-8272-42b6-8a2b-93b002e25f38)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to form field labels, allowing users to view schema descriptions by hovering over an info icon.

* **Style**
  * Updated the appearance of class list item icons in the settings panel, including reduced icon size and a new semi-transparent color for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->