### PR TITLE
fix(double click issue in inline blocks): update setIds logic to conditionally set blockId

### DIFF
--- a/src/core/components/canvas/static/with-block-text-editor.tsx
+++ b/src/core/components/canvas/static/with-block-text-editor.tsx
@@ -268,7 +268,7 @@ const WithBlockTextEditor = memo(
         setEditingElement(null);
         setEditingBlockId(null);
         setEditingItemIndex(-1);
-        setIds([]);
+        setIds(blockId ? [blockId] : []);
       },
       [blockId, updateContent, setEditingBlockId, setIds, selectedLang],
     );


### PR DESCRIPTION
[Screencast from 2025-08-11 12-35-53.webm](https://github.com/user-attachments/assets/8c6ced54-2a00-4f7b-8724-e4376cb89756)
