### PR TITLE
Fix useIsPageLoaded hook to return state correctly

### DIFF
--- a/src/core/hooks/use-is-page-loaded.ts
+++ b/src/core/hooks/use-is-page-loaded.ts
@@ -4,6 +4,5 @@ export const isPageLoadedAtom = atom<boolean>(false);
 
 // * Hook to identify if the builder is ready
 export const useIsPageLoaded = () => {
-  const [isPageLoaded] = useAtom(isPageLoadedAtom);
-  return isPageLoaded;
+  return useAtom(isPageLoadedAtom);
 };

--- a/src/core/hooks/use-save-page.ts
+++ b/src/core/hooks/use-save-page.ts
@@ -44,7 +44,7 @@ export const useSavePage = () => {
   const [theme] = useTheme();
   const { hasPermission } = usePermissions();
   const { selectedLang, fallbackLang } = useLanguages();
-  const isPageLoaded = useIsPageLoaded();
+  const [isPageLoaded] = useIsPageLoaded();
 
   const needTranslations = () => {
     const pageData = getPageData();


### PR DESCRIPTION
Update the `useIsPageLoaded` hook to return the correct state, ensuring proper usage in other components.