### PR TITLE
fix: add negative top margin to outline panel to remove extra spacing

### DIFF
--- a/src/core/components/layout/root-layout.tsx
+++ b/src/core/components/layout/root-layout.tsx
@@ -77,7 +77,7 @@ registerChaiSidebarPanel("outline", {
   isInternal: true,
   width: DEFAULT_PANEL_WIDTH,
   panel: () => (
-    <div className="">
+    <div className="-mt-8">
       <Outline />
     </div>
   ),


### PR DESCRIPTION
<img width="355" height="944" alt="image" src="https://github.com/user-attachments/assets/1e341da6-1afb-4e3c-b8bd-fe83f592de94" />
