### PR TITLE
feat: enhance i18n block translation fallback logic

### DIFF
--- a/src/_demo/ai-chat-panel.tsx
+++ b/src/_demo/ai-chat-panel.tsx
@@ -23,7 +23,7 @@ export default function AIChatPanel() {
       <textarea className="mt-10" rows={5} value={html} onChange={(e) => setHtml(e.target.value)}></textarea>
       <Button onClick={add}>Import HTML</Button>
       <Button onClick={() => console.log(blocksHtmlForAi())}>Get Blocks HTML</Button>
-      <Button onClick={() => console.log(i18nBlocks("ALL"))}>Get I18n Blocks</Button>
+      <Button onClick={() => console.log(i18nBlocks("fr"))}>Get I18n Blocks</Button>
     </div>
   );
 }

--- a/src/core/hooks/use-i18n-blocks.ts
+++ b/src/core/hooks/use-i18n-blocks.ts
@@ -1,5 +1,5 @@
 import { getRegisteredChaiBlock } from "@chaibuilder/runtime";
-import { compact, pick } from "lodash";
+import { compact, each, get, pick } from "lodash";
 import { useCallback } from "react";
 import { getBlockWithNestedChildren } from "./get-block-with-nested-children";
 import { useBlocksStore } from "./hooks";
@@ -22,7 +22,11 @@ export const useI18nBlocks = () => {
             lang === "ALL"
               ? Object.keys(block).filter((key) => i18nProps.find((prop) => key.startsWith(prop)))
               : i18nProps.map((prop) => (lang ? `${prop}-${lang}` : prop));
-          return pick(block, [...keys, "_id"]);
+          const blockProps = pick(block, ["_id"]);
+          each(keys, (key) => {
+            blockProps[key] = get(block, key, get(block, key.replace(`-${lang}`, "")));
+          });
+          return blockProps;
         }),
       );
     },


### PR DESCRIPTION
- Added fallback to default language when translated content is missing for specified language
- Modified i18n block extraction to preserve original content when translation is unavailable
- Updated demo panel to use "fr" as example language instead of "ALL"
- Improved block property handling to ensure consistent translation behavior