### PR TITLE
feat: add custom button styling options to screen size breakpoint controls

### DIFF
--- a/src/_demo/custom-layout.tsx
+++ b/src/_demo/custom-layout.tsx
@@ -77,7 +77,7 @@ export default function CustomLayout() {
         <div className="flex h-16 items-center justify-between bg-neutral-900 px-4 text-white">
           <h1 className="ml-4 font-bold">Custom Layout Example</h1>
           <div className={`flex items-center space-x-2`}>
-            <ChaiScreenSizes />
+            <ChaiScreenSizes buttonClass={"text-yellow-500 hover:text-yellow-500"} activeButtonClass={"text-green-500 hover:text-green-500"} />
             |
             <ChaiUndoRedo />
           </div>

--- a/src/core/components/canvas/topbar/canvas-breakpoints.tsx
+++ b/src/core/components/canvas/topbar/canvas-breakpoints.tsx
@@ -28,6 +28,8 @@ export interface BreakpointCardProps extends BreakpointItemType {
   onClick: Function;
   openDelay?: number;
   tooltip?: boolean;
+  buttonClass?: string;
+  activeButtonClass?: string;
 }
 
 const TabletIcon = ({ landscape = false, className = "" }) => (
@@ -98,6 +100,8 @@ const BreakpointCard = ({
   width,
   icon,
   onClick,
+  buttonClass = "",
+  activeButtonClass = "",
 }: BreakpointCardProps) => {
   const { t } = useTranslation();
 
@@ -119,7 +123,7 @@ const BreakpointCard = ({
         <Button
           onClick={() => onClick(width)}
           size="sm"
-          className="h-7 w-7 rounded-md p-1"
+          className={cn("h-7 w-7 rounded-md p-1", breakpoint === currentBreakpoint ? activeButtonClass : buttonClass)}
           variant={breakpoint === currentBreakpoint ? "outline" : "ghost"}>
           {icon}
         </Button>
@@ -140,10 +144,14 @@ export const Breakpoints = ({
   openDelay = 400,
   canvas = false,
   tooltip = true,
+  buttonClass = "",
+  activeButtonClass = "",
 }: {
   openDelay?: number;
   canvas?: boolean;
   tooltip?: boolean;
+  buttonClass?: string;
+  activeButtonClass?: string;
 }) => {
   const [currentWidth, , setNewWidth] = useScreenSizeWidth();
   const [canvasDisplayWidth, setCanvasDisplayWidth] = useCanvasDisplayWidth();
@@ -205,6 +213,8 @@ export const Breakpoints = ({
               onClick={handleCanvasWidthChange}
               key={bp.breakpoint}
               currentBreakpoint={breakpoint}
+              buttonClass={buttonClass}
+              activeButtonClass={activeButtonClass}
             />
           ),
         )}


### PR DESCRIPTION
[Screencast from 2025-11-10 15-25-58.webm](https://github.com/user-attachments/assets/8b57dd2b-1dd1-42cb-a51c-da6b8c088ea9)
