### PR TITLE
feat: add Promise.allSettled to wait for data providers before rendering

### DIFF
--- a/src/render/async/async-render-chai-blocks.tsx
+++ b/src/render/async/async-render-chai-blocks.tsx
@@ -88,5 +88,9 @@ export async function AsyncRenderChaiBlocks(props: RenderChaiBlocksProps) {
     },
     {} as Record<string, Promise<Record<string, any>>>,
   );
+
+  // Wait for all data provider promises to settle
+  await Promise.allSettled(Object.values(dataProviders));
+
   return <AsyncRenderBlocks {...props} lang={lang} fallbackLang={fallbackLang} dataProviders={dataProviders} />;
 }


### PR DESCRIPTION
- Add await Promise.allSettled call to ensure all data provider promises settle before rendering
- Add comment explaining the purpose of waiting for data providers