### PR TITLE
chore: upgrade react-hotkeys-hook to 5.2.1 and standardize hotkey bin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "react-autosuggest": "10.1.0",
     "react-colorful": "5.6.1",
     "react-error-boundary": "^6.0.0",
-    "react-hotkeys-hook": "5.1.0",
+    "react-hotkeys-hook": "5.2.1",
     "react-i18next": "16.0.0",
     "react-wrap-balancer": "^1.1.1",
     "sonner": "^2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(react@19.2.0)
       react-hotkeys-hook:
-        specifier: 5.1.0
-        version: 5.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 5.2.1
+        version: 5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-i18next:
         specifier: 16.0.0
         version: 16.0.0(i18next@25.5.2(typescript@5.7.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.7.3)
@@ -4703,8 +4703,8 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
-  react-hotkeys-hook@5.1.0:
-    resolution: {integrity: sha512-GCNGXjBzV9buOS3REoQFmSmE4WTvBhYQ0YrAeeMZI83bhXg3dRWsLHXDutcVDdEjwJqJCxk5iewWYX5LtFUd7g==}
+  react-hotkeys-hook@5.2.1:
+    resolution: {integrity: sha512-xbKh6zJxd/vJHT4Bw4+0pBD662Fk20V+VFhLqciCg+manTVO4qlqRqiwFOYelfHN9dBvWj9vxaPkSS26ZSIJGg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -10551,7 +10551,7 @@ snapshots:
       '@babel/runtime': 7.28.2
       react: 19.2.0
 
-  react-hotkeys-hook@5.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-hotkeys-hook@5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)

--- a/src/core/flags/flags-widget.tsx
+++ b/src/core/flags/flags-widget.tsx
@@ -1,11 +1,10 @@
-import { Switch, Input, Button } from "@/ui";
+import { Button, Input, Switch } from "@/ui";
+import { Cross1Icon, DragHandleDots2Icon, MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { MagnifyingGlassIcon, Cross1Icon } from "@radix-ui/react-icons";
+import { useEffect, useMemo, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useState, useMemo, useEffect } from "react";
 import { useChaiFeatureFlag, useChaiFeatureFlags, useToggleChaiFeatureFlag } from "./register-chai-flag";
-import { DragHandleDots2Icon } from "@radix-ui/react-icons";
 
 const FeatureToggle = ({
   featureKey,
@@ -171,7 +170,7 @@ const ChaiFeatureFlagsWidgetComponent = ({
 export const ChaiFeatureFlagsWidget = () => {
   const [show, setShow] = useAtom(showFeatureFlagAtom);
   useHotkeys(
-    "ctrl+shift+1,command+shift+1",
+    "ctrl+shift+1,meta+shift+1",
     () =>
       setShow((prev) => {
         if (!prev) {

--- a/src/core/hooks/use-key-event-watcher.ts
+++ b/src/core/hooks/use-key-event-watcher.ts
@@ -1,6 +1,6 @@
 import { canDeleteBlock } from "@/core/functions/block-helpers";
-import { useCopyBlockIds, useCutBlockIds, useUndoManager } from "@/core/hooks";
 import { undoManager } from "@/core/history/use-undo-manager";
+import { useCopyBlockIds, useCutBlockIds, useUndoManager } from "@/core/hooks";
 import { useDuplicateBlocks } from "@/core/hooks/use-duplicate-blocks";
 import { usePasteBlocks } from "@/core/hooks/use-paste-blocks";
 import { useRemoveBlocks } from "@/core/hooks/use-remove-blocks";
@@ -20,7 +20,7 @@ export const useKeyEventWatcher = (doc?: Document) => {
   const options = doc ? { document: doc } : {};
 
   useHotkeys(
-    "ctrl+z,command+z",
+    "ctrl+z,meta+z",
     (e) => {
       e.preventDefault();
       if (undoManager.hasUndo()) {
@@ -31,7 +31,7 @@ export const useKeyEventWatcher = (doc?: Document) => {
     [undo],
   );
   useHotkeys(
-    "ctrl+y,command+z",
+    "ctrl+y,meta+y",
     (e) => {
       e.preventDefault();
       if (undoManager.hasRedo()) {
@@ -42,7 +42,7 @@ export const useKeyEventWatcher = (doc?: Document) => {
     [redo],
   );
   useHotkeys(
-    "ctrl+x,command+x",
+    "ctrl+x,meta+x",
     (e) => {
       e.preventDefault();
       if (!isEmpty(ids)) {
@@ -53,13 +53,13 @@ export const useKeyEventWatcher = (doc?: Document) => {
     [ids, setCutBlockIds],
   );
   useHotkeys(
-    "ctrl+c,command+c",
+    "ctrl+c,meta+c",
     () => setCopyBlockIds(ids),
-    { ...options,  enabled: !isEmpty(ids), preventDefault: true },
+    { ...options, enabled: !isEmpty(ids), preventDefault: true },
     [ids, setCopyBlockIds],
   );
   useHotkeys(
-    "ctrl+v,command+v",
+    "ctrl+v,meta+v",
     () => {
       if (canPaste(ids[0])) {
         pasteBlocks(ids);
@@ -70,10 +70,12 @@ export const useKeyEventWatcher = (doc?: Document) => {
   );
 
   useHotkeys("esc", () => setIds([]), options, [setIds]);
-  useHotkeys("ctrl+d,command+d", () => duplicateBlocks(ids), { ...options, enabled: !isEmpty(ids), preventDefault: true }, [
-    ids,
-    duplicateBlocks,
-  ]);
+  useHotkeys(
+    "ctrl+d,meta+d",
+    () => duplicateBlocks(ids),
+    { ...options, enabled: !isEmpty(ids), preventDefault: true },
+    [ids, duplicateBlocks],
+  );
   useHotkeys(
     "del, backspace",
     (event: any) => {


### PR DESCRIPTION
…dings

- Update react-hotkeys-hook from 5.1.0 to 5.2.1
- Replace 'command' modifier with 'meta' across all hotkey bindings for cross-platform consistency
- Fix redo hotkey from ctrl+y,meta+z to ctrl+y,meta+y
- Reformat duplicate blocks hotkey binding for consistency