### PR TITLE
feat: improve token usage navigation with page switching and UI refinements

### DIFF
--- a/src/core/components/settings/new-panel/token-usage-popover.tsx
+++ b/src/core/components/settings/new-panel/token-usage-popover.tsx
@@ -1,10 +1,10 @@
-import { DESIGN_TOKEN_PREFIX } from "@/core/constants/STRINGS";
-import { useBlocksStore, useBuilderProp } from "@/core/hooks";
+import { useBlocksStore, useBuilderProp, useLanguages, useSavePage } from "@/core/hooks";
 import { useSelectedBlockIds } from "@/core/hooks/use-selected-blockIds";
 import { ChaiBlock } from "@/types/chai-block";
 import { Button } from "@/ui/shadcn/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/shadcn/components/ui/popover";
-import { BoxIcon, EyeOpenIcon, FileIcon, GlobeIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon, EyeOpenIcon, FileIcon, GlobeIcon } from "@radix-ui/react-icons";
+import { noop } from "lodash-es";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { TokenUsageSection, TokenUsageSectionItem } from "./token-usage-section";
@@ -36,7 +36,7 @@ const getBlockLabel = (block: ChaiBlock): string => {
 };
 
 const collectTokenUsageOnPage = (blocks: ChaiBlock[], tokenId: string): BlockUsageSummary[] => {
-  const tokenMarker = `${DESIGN_TOKEN_PREFIX}${tokenId}`;
+  const tokenMarker = `${tokenId}`;
 
   return blocks
     .filter((block) => {
@@ -118,12 +118,13 @@ export const TokenUsagePopover = ({ tokenId, tokenName }: TokenUsagePopoverProps
     },
     [setSelectedBlockIds],
   );
-
-  const handleSelectPage = (pageId: string) => {
+  const gotoPage = useBuilderProp("gotoPage", noop);
+  const { selectedLang, fallbackLang } = useLanguages();
+  const { savePageAsync } = useSavePage();
+  const handleSelectPage = async (pageId: string) => {
     if (!pageId) return;
-    const url = new URL(window.location.href);
-    url.searchParams.set("pageId", pageId);
-    window.open(url.toString(), "_blank");
+    await savePageAsync(true);
+    gotoPage({ pageId, lang: selectedLang || fallbackLang });
   };
 
   return (
@@ -146,7 +147,7 @@ export const TokenUsagePopover = ({ tokenId, tokenName }: TokenUsagePopoverProps
             items={currentPageItems}
             emptyLabel={t("None")}
             onSelect={handleSelectBlock}
-            icon={<BoxIcon fontSize={8} />}
+            icon={<ArrowRightIcon fontSize={4} />}
           />
           <TokenUsageSection
             title={t("Blocks affected on other pages")}

--- a/src/core/components/settings/new-panel/token-usage-section.tsx
+++ b/src/core/components/settings/new-panel/token-usage-section.tsx
@@ -27,20 +27,19 @@ export const TokenUsageSection = ({ title, items, emptyLabel, onSelect, icon }: 
               type="button"
               onClick={() => onSelect(item.id)}
               className={cn(
-                "group flex w-full items-center justify-between rounded-md border border-transparent bg-muted/40 px-3 py-2 text-left text-xs transition",
+                "group flex w-full items-center justify-between rounded-md border border-transparent bg-muted/40 px-3 py-1 text-left text-xs transition",
                 "hover:border-muted-foreground/20 hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-1",
                 item.isSelected && "border-primary/40 bg-primary/10 text-primary",
               )}>
               <span className="flex items-center space-x-2">
                 {icon && icon}
-                <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 group-hover:bg-primary/60" />
                 <span className="truncate">{item.label}</span>
               </span>
             </button>
           ))}
         </div>
       ) : (
-        <div className="rounded border border-dashed border-muted px-3 py-2 text-xs text-muted-foreground">
+        <div className="rounded border border-dashed border-muted px-3 py-1 text-xs text-muted-foreground">
           {emptyLabel}
         </div>
       )}


### PR DESCRIPTION
…

- Replace new tab navigation with in-app page switching using gotoPage
- Add auto-save before navigating to ensure changes are preserved
- Remove design token prefix from token marker matching
- Update icon from BoxIcon to ArrowRightIcon for better visual clarity
- Remove redundant dot indicator from usage items
- Reduce vertical padding in usage items for more compact layout
- Import useLanguages and useSavePage hooks for