### PR TITLE
fix: use builderStore.get to fetch latest blocks state in undoable ac…

### DIFF
--- a/src/core/history/use-blocks-store-undoable-actions.ts
+++ b/src/core/history/use-blocks-store-undoable-actions.ts
@@ -1,4 +1,5 @@
 import { presentBlocksAtom } from "@/core/atoms/blocks";
+import { builderStore } from "@/core/atoms/store";
 import { useBlocksStoreManager } from "@/core/history/use-blocks-store-manager";
 import { useUndoManager } from "@/core/history/use-undo-manager";
 import { ChaiBlock } from "@/types/chai-block";
@@ -21,9 +22,10 @@ export const useBlocksStoreUndoableActions = () => {
   } = useBlocksStoreManager();
 
   const setNewBlocks = (newBlocks: ChaiBlock[]) => {
+    const previousBlocks = builderStore.get(presentBlocksAtom) as ChaiBlock[];
     setBlocks(newBlocks);
     add({
-      undo: () => setBlocks(currentBlocks),
+      undo: () => setBlocks(previousBlocks),
       redo: () => setBlocks(newBlocks),
     });
   };
@@ -37,8 +39,9 @@ export const useBlocksStoreUndoableActions = () => {
   };
 
   const removeBlocks = (blocks: ChaiBlock[]) => {
+    const latestBlocks = builderStore.get(presentBlocksAtom) as ChaiBlock[];
     const parentId = first(blocks)?._parent;
-    const siblings = currentBlocks.filter((block) => (parentId ? block._parent === parentId : !block._parent));
+    const siblings = latestBlocks.filter((block) => (parentId ? block._parent === parentId : !block._parent));
     const position = siblings.indexOf(first(blocks));
 
     removeExistingBlocks(map(blocks, "_id"));

--- a/src/core/hooks/use-replace-block.ts
+++ b/src/core/hooks/use-replace-block.ts
@@ -1,4 +1,6 @@
-import { useBlocksStore, useBlocksStoreUndoableActions } from "@/core/history/use-blocks-store-undoable-actions";
+import { presentBlocksAtom } from "@/core/atoms/blocks";
+import { builderStore } from "@/core/atoms/store";
+import { useBlocksStoreUndoableActions } from "@/core/history/use-blocks-store-undoable-actions";
 import { useSelectedBlockIds } from "@/core/hooks/use-selected-blockIds";
 import { PERMISSIONS, usePermissions } from "@/core/main";
 import { ChaiBlock } from "@/types/chai-block";
@@ -52,7 +54,6 @@ export const replaceBlock = (blocks: ChaiBlock[], blockId: string, replacementBl
 };
 
 export const useReplaceBlock = () => {
-  const [presentBlocks] = useBlocksStore();
   const [, setSelectedIds] = useSelectedBlockIds();
   const { setNewBlocks } = useBlocksStoreUndoableActions();
   const { hasPermission } = usePermissions();
@@ -60,13 +61,14 @@ export const useReplaceBlock = () => {
   return useCallback(
     (blockId: string | undefined, replacementBlocks: ChaiBlock[]) => {
       if (!hasPermission(PERMISSIONS.EDIT_BLOCK)) return;
-      const newBlocks = blockId ? replaceBlock(presentBlocks, blockId, replacementBlocks) : replacementBlocks;
+      const latestUpdatedBlocks = builderStore.get(presentBlocksAtom) as ChaiBlock[];
+      const newBlocks = blockId ? replaceBlock(latestUpdatedBlocks, blockId, replacementBlocks) : replacementBlocks;
       setNewBlocks(newBlocks);
       // Select the first replacement block after replace
       if (replacementBlocks.length > 0) {
         setTimeout(() => setSelectedIds([replacementBlocks[0]._id]), 200);
       }
     },
-    [presentBlocks, setSelectedIds, setNewBlocks, hasPermission],
+    [setSelectedIds, setNewBlocks, hasPermission],
   );
 };


### PR DESCRIPTION
**Root cause (confirmed)**
useReplaceBlock captures presentBlocks at render time. If you call the returned function multiple times before the component re-renders, it will keep using the old presentBlocks snapshot, so earlier replacements get “lost” when the next replace is computed.

Also, your undoable setNewBlocks captures currentBlocks similarly, which can make the undo stack incorrect.