### PR TITLE
fix: replace defaultChecked with checked prop in link target checkbox

### DIFF
--- a/src/core/rjsf-widgets/link.tsx
+++ b/src/core/rjsf-widgets/link.tsx
@@ -258,7 +258,7 @@ const LinkField = ({ schema, formData, onChange, name }: FieldProps) => {
               autoCorrect={"off"}
               spellCheck={"false"}
               type="checkbox"
-              defaultChecked={target === "_blank"}
+              checked={target === "_blank"}
               className="!w-fit cursor-pointer rounded-md border border-border"
               onChange={() => onChange({ ...formData, target: target === "_blank" ? "_self" : "_blank" })}
             />


### PR DESCRIPTION
The checkbox was using defaultChecked instead of checked, which meant the checkbox value was only set once when the component initially mounted and wouldn't update when switching between different link blocks with different target attributes.