### PR TITLE
chore: add GitHub workflow to auto-list PRs in dev→main merge request [#543]

### DIFF
--- a/.github/workflows/dev-to-main-list-prs.yml
+++ b/.github/workflows/dev-to-main-list-prs.yml
@@ -1,0 +1,145 @@
+name: PR (dev → main) • Append included PR numbers + dates
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-title-and-body:
+    if: (github.event.pull_request.base.ref == 'main') && github.event.pull_request.head.ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect new PRs from dev diff and update this PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // 1) New commits between base (main/master) and head (staging) of THIS PR
+            const compare = await github.rest.repos.compareCommits({
+              owner, repo,
+              base: pr.base.sha,
+              head: pr.head.sha
+            });
+
+            if (!compare.data.commits?.length) {
+              core.info("No new commits between base and head.");
+              return;
+            }
+
+            // 2) Associate each commit to its original PR via the commits/{sha}/pulls API
+            const candidatePRs = new Map(); // num -> meta
+            for (const c of compare.data.commits) {
+              const resp = await github.request(
+                "GET /repos/{owner}/{repo}/commits/{ref}/pulls",
+                {
+                  owner, repo, ref: c.sha,
+                  headers: { accept: "application/vnd.github+json" }
+                }
+              );
+              for (const linked of resp.data) {
+                // Keep only merged PRs, other than the current PR
+                if (
+                  linked.number !== pr.number &&
+                  linked.state === "closed" &&
+                  linked.merged_at
+                ) {
+                  candidatePRs.set(linked.number, { merged_at: linked.merged_at });
+                }
+              }
+            }
+
+            if (candidatePRs.size === 0) {
+              core.info("No merged PRs found in this dev→main diff.");
+              return;
+            }
+
+            // 3) Retrieve author and title for each PR found
+            const enriched = [];
+            for (const num of Array.from(candidatePRs.keys()).sort((a,b)=>a-b)) {
+              const { data: full } = await github.rest.pulls.get({ owner, repo, pull_number: num });
+              enriched.push({
+                num,
+                title: full.title,
+                mergedAt: full.merged_at, // Keep full timestamp for sorting
+                mergedAtISODate: full.merged_at ? new Date(full.merged_at).toISOString().split("T")[0] : null, // Display date only
+                authorBy: full.user ? full.user.login : null
+              });
+            }
+
+            // 4) Build the title suffix and body section
+            const suffix = "[" + enriched.map(p => `#${p.num}`).join(" ") + "]";
+            const cleanedTitle = pr.title.replace(/\s*\[(?:#\d+\s*)+\]\s*$/g, "").trim();
+            const newTitle = `${cleanedTitle} ${suffix}`.trim();
+
+            const startTag = "<!-- included-prs:start -->";
+            const endTag   = "<!-- included-prs:end -->";
+
+            // Helper function to format a PR row
+            const formatPRRow = (p) => {
+              // Extract issue numbers from title (supports various formats like #123, fixes #123, closes #456, etc.)
+              const issueMatches = p.title.match(/(?:fix(?:es)?|close(?:s)?|resolve(?:s)?)\s*#(\d+)|#(\d+)/gi);
+              const issues = issueMatches ? issueMatches.map(match => {
+                const num = match.match(/#(\d+)/)[1];
+                return `#${num}`;
+              }).join(', ') : '';
+              
+              // Clean title by removing issue references for cleaner display
+              const cleanTitle = p.title.replace(/(?:fix(?:es)?|close(?:s)?|resolve(?:s)?)\s*#\d+/gi, '').replace(/#\d+/g, '').trim();
+              
+              // Plain text PR reference with title, date, and fixes on new line
+              const mergedDate = p.mergedAtISODate || 'N/A';
+              let prWithTitle = `#${p.num} ${cleanTitle} (${mergedDate})`;
+              if (issues) {
+                prWithTitle += `<br/>**Fixes:** ${issues}`;
+              }
+              const authorBy = p.authorBy ? `@${p.authorBy}` : 'N/A';
+              
+              return `| ${prWithTitle} | ${authorBy} |`;
+            };
+
+            // Sort by merge timestamp (most recent first) for main table
+            const sortedByDate = [...enriched].sort((a, b) => {
+              const dateA = a.mergedAt || '';
+              const dateB = b.mergedAt || '';
+              return dateB.localeCompare(dateA); // Descending order (ISO timestamps compare correctly as strings)
+            });
+
+            // Main table sorted by merge date
+            const tableRowsByDate = sortedByDate.map(formatPRRow).join('\n');
+
+            // Alternative table sorted by PR number (original order)
+            const tableRowsByNumber = enriched.map(formatPRRow).join('\n');
+
+            const header = `### Included PRs (dev → ${pr.base.ref})`;
+            const tableHeader = `| PR & Title | Opened By |\n|------------|-----------|` + '\n';
+
+            // Main table (sorted by merge date)
+            const mainTable = `${header}\n\n${tableHeader}${tableRowsByDate}`;
+
+            // Alternative table in collapsible details (sorted by PR number)
+            const altTable = `\n\n<details>\n<summary>View by PR number</summary>\n\n${tableHeader}${tableRowsByNumber}\n\n</details>`;
+
+            const section = `${startTag}\n${mainTable}${altTable}\n${endTag}`;
+
+            const body = pr.body || "";
+            const newBody = (body.includes(startTag) && body.includes(endTag))
+              ? body.replace(new RegExp(`${startTag}[\\s\\S]*?${endTag}`), section)
+              : `${section}\n\n${body}`.trim();
+
+            // 5) Apply updates to the PR
+            await github.rest.pulls.update({
+              owner, repo, pull_number: pr.number,
+              title: newTitle,
+              body: newBody
+            });
+
+            core.info(`Updated title: ${newTitle}`);
+            core.info(`Included PRs: ${enriched.map(e => e.num).join(", ")}`);


### PR DESCRIPTION
<!-- included-prs:start -->
### Included PRs (dev → main)

| PR & Title | Opened By |
|------------|-----------|
| #543 chore: add GitHub workflow to auto-list PRs in dev→main merge request (2026-01-20) | @surajair |

<details>
<summary>View by PR number</summary>

| PR & Title | Opened By |
|------------|-----------|
| #543 chore: add GitHub workflow to auto-list PRs in dev→main merge request (2026-01-20) | @surajair |

</details>
<!-- included-prs:end -->