### PR TITLE
fix: improve error handling and empty state display in UI library blocks

### DIFF
--- a/src/core/components/sidepanels/panels/add-blocks/libraries-panel.tsx
+++ b/src/core/components/sidepanels/panels/add-blocks/libraries-panel.tsx
@@ -121,7 +121,7 @@ const UILibrarySection = ({
   const [selectedLibrary, setLibrary] = useSelectedLibrary();
   const uiLibraries = useChaiLibraries();
   const library = uiLibraries.find((library) => library.id === selectedLibrary) || first(uiLibraries);
-  const { data: libraryBlocks, isLoading, resetLibrary } = useLibraryBlocks(library);
+  const { data: libraryBlocks, isLoading, isError, resetLibrary } = useLibraryBlocks(library);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<ChaiLibraryBlock[]>([]);
 
@@ -227,7 +227,7 @@ const UILibrarySection = ({
                     <div className="mt-4 flex flex-col items-center justify-center gap-3 p-4 text-center">
                       {searchQuery ? (
                         <p className="text-sm">{t("No matching blocks found")}</p>
-                      ) : (
+                      ) : isError ? (
                         <>
                           <p className="text-sm">{t("Failed to load the UI library. Try again")}</p>
                           <Button onClick={handleRetry} variant="outline" size="sm" className="gap-2">
@@ -235,6 +235,8 @@ const UILibrarySection = ({
                             {t("Retry")}
                           </Button>
                         </>
+                      ) : (
+                        <p className="text-sm">{t("This library is empty")}</p>
                       )}
                     </div>
                   ) : fromSidebar ? (

--- a/src/pages/hooks/project/use-block-library-mutations.ts
+++ b/src/pages/hooks/project/use-block-library-mutations.ts
@@ -1,7 +1,9 @@
+import { libraryBlocksAtom } from "@/hooks/use-library-blocks";
 import { ACTIONS } from "@/pages/constants/ACTIONS";
 import { useFetch } from "@/pages/hooks/utils/use-fetch";
 import { ChaiBlock } from "@/types/common";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useSetAtom } from "jotai";
 import { toast } from "sonner";
 import { useApiUrl } from "./use-builder-prop";
 
@@ -102,6 +104,7 @@ export const useUploadBlockPreview = (onSuccess?: () => void) => {
 export const useDeleteUIBlock = (onSuccess?: () => void) => {
   const apiUrl = useApiUrl();
   const fetchAPI = useFetch();
+  const setLibraryBlocks = useSetAtom(libraryBlocksAtom);
 
   return useMutation({
     mutationFn: async (blockId: string) => {
@@ -111,6 +114,15 @@ export const useDeleteUIBlock = (onSuccess?: () => void) => {
       });
     },
     onSuccess: () => {
+      // Reset all library caches to force refetch
+      setLibraryBlocks((prev) => {
+        const updated = { ...prev };
+        Object.keys(updated).forEach((libraryId) => {
+          updated[libraryId] = { loading: "idle", blocks: [], error: false };
+        });
+        return updated;
+      });
+
       if (onSuccess) {
         onSuccess();
       } else {

--- a/src/pages/hooks/project/use-ui-libraries.ts
+++ b/src/pages/hooks/project/use-ui-libraries.ts
@@ -18,18 +18,13 @@ const uiLibrariesChaiApi = {
   },
 
   async getUILibraryBlocks(uiLibrary: ChaiLibrary, fetchAPI: any, apiUrl: string) {
-    try {
-      const response = await fetchAPI(apiUrl, {
-        action: "GET_LIBRARY_ITEMS",
-        data: { id: uiLibrary.id },
-      });
-      return response.map((b: { preview: string }) => ({
-        ...b,
-      }));
-    } catch (_e: unknown) {
-      console.error(_e);
-      return [];
-    }
+    const response = await fetchAPI(apiUrl, {
+      action: "GET_LIBRARY_ITEMS",
+      data: { id: uiLibrary.id },
+    });
+    return response.map((b: { preview: string }) => ({
+      ...b,
+    }));
   },
 };
 


### PR DESCRIPTION
- Add error state tracking to libraryBlocksAtom and useLibraryBlocks hook
- Differentiate between error state and empty library in UI display
- Show "This library is empty" message when no blocks exist vs error retry UI
- Remove try-catch in getUILibraryBlocks to properly propagate errors
- Reset all library caches when deleting a UI block to force refetch
- Export libraryBlocksAtom for use in block library mutations

Fixes: #643 