### PR TITLE
feat: add settings field to ChaiWebsiteSetting type

### DIFF
--- a/docs/types-reference.md
+++ b/docs/types-reference.md
@@ -648,6 +648,7 @@ type ChaiWebsiteSetting = {
   fallbackLang: string;
   languages: string[];
   theme: ChaiTheme;
+  settings: Record<string, any>;
   designTokens: ChaiDesignTokens;
 };
 ```

--- a/src/pages/hooks/project/use-website-settings.ts
+++ b/src/pages/hooks/project/use-website-settings.ts
@@ -16,6 +16,7 @@ export const useWebsiteSetting = () => {
       theme: defaultThemeValues,
       appKey: "",
       fallbackLang: "",
+      settings: {},
       designTokens: {},
     },
     queryFn: async () => {

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -8,6 +8,7 @@ export type ChaiWebsiteSetting = {
   fallbackLang: string;
   languages: string[];
   theme: ChaiTheme;
+  settings: Record<string, any>;
   designTokens: ChaiDesignTokens;
 };
 


### PR DESCRIPTION
- Add settings property as Record<string, any> to ChaiWebsiteSetting type
- Initialize settings as empty object in useWebsiteSetting hook
- Update type documentation