### PR TITLE
Update ChaiWebsiteBuilder flags usage and rename SEO reset flag

### DIFF
--- a/src/pages/chaibuilder-pages.tsx
+++ b/src/pages/chaibuilder-pages.tsx
@@ -255,7 +255,7 @@ const ChaiWebsiteBuilder = (props: ChaiWebsiteBuilderProps) => {
         "websocket",
         "realtimeAdapter",
         "getLoggedInUser",
-        "features",
+        "flags",
         "currentUser",
       ]),
     );

--- a/src/pages/client/components/seo-panel.tsx
+++ b/src/pages/client/components/seo-panel.tsx
@@ -135,7 +135,7 @@ const SeoPanel = () => {
   const { hasPermission } = usePermissions();
   const editSeo = hasPermission(PAGES_PERMISSIONS.EDIT_SEO);
   const [pagesProps] = usePagesProps();
-  const canResetSeoToDefault = get(pagesProps, "features.canResetSeoToDefault", false);
+  const resetSeoToDefault = get(pagesProps, "flags.resetSeoToDefault", false);
 
   const hasJsonLdForSelectedLang = !selectedLang || formValues.jsonLD !== "{}";
 
@@ -769,7 +769,7 @@ const SeoPanel = () => {
 
       {editSeo && (
         <div className="fixed bottom-0 left-0 right-0 flex w-full flex-shrink-0 items-center justify-between border-t bg-background p-4">
-          {canResetSeoToDefault ? (
+          {resetSeoToDefault ? (
             <Button
               type="button"
               variant="ghost"

--- a/src/pages/client/components/smart-json-input.tsx
+++ b/src/pages/client/components/smart-json-input.tsx
@@ -49,7 +49,7 @@ export const SmartJsonInput: React.FC<SmartJsonInputProps> = ({
   const [previewJson, setPreviewJson] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [pagesProps] = usePagesProps();
-  const isShareJsonLdEnabled = id === "jsonLD" && get(pagesProps, "features.sharedJsonLD", false);
+  const isShareJsonLdEnabled = id === "jsonLD" && get(pagesProps, "flags.sharedJsonLD", false);
   const showOptionToCopyJsonLd = id === "jsonLD" && !hasJsonLdForSelectedLang && !!copyJsonLDFromDefaultPage;
 
   useEffect(() => {

--- a/src/types/chaibuilder-editor-props.ts
+++ b/src/types/chaibuilder-editor-props.ts
@@ -282,6 +282,8 @@ export interface ChaiBuilderEditorProps {
     validateStructure?: boolean;
     designTokens?: boolean;
     ai?: boolean;
+    sharedJsonLD?: boolean;
+    resetSeoToDefault?: boolean;
   };
 
   //TODO: Move to registerChaiStructureRules()

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -55,7 +55,6 @@ export type ChaiWebsiteBuilderProps = {
   getAccessToken?: () => Promise<string>;
   currentUser: LoggedInUser | null;
   websocket?: any;
-  features?: { sharedJsonLD?: boolean; canResetSeoToDefault?: boolean } & Record<string, boolean>;
   realtimeAdapter?: RealtimeAdapter;
 } & Pick<
   ChaiBuilderEditorProps,


### PR DESCRIPTION
Summary
- replace usage of the deprecated `features` prop with `flags` across the builder and components
- capture new `flags` properties (`sharedJsonLD`, `resetSeoToDefault`) in props and types, and add the extra `settings` bag to website settings
- update imports to use `lodash-es` for runtime font helpers

Testing
- Not run (not requested)