### PR TITLE
feat: page type search by removing the page type dropdown and implementing client-side filtering

### DIFF
--- a/src/core/rjsf-widgets/link.tsx
+++ b/src/core/rjsf-widgets/link.tsx
@@ -9,26 +9,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DataBindingSelector } from "./data-binding-selector";
 
-const PageTypeField = ({
-  href,
-  pageTypes,
-  onChange,
-}: {
-  href: string;
-  pageTypes: any[];
-  onChange: (href: string) => void;
-}) => {
+const PageTypeField = ({ href, onChange }: { href: string; onChange: (href: string) => void }) => {
   const { t } = useTranslation();
   const searchPageTypeItems = useBuilderProp("searchPageTypeItems", (_: string, __: any) => []);
   const [loading, setLoading] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
-  const [pageType, setPageType] = useState("page");
   const [searchQuery, setSearchQuery] = useState("");
   const [pageTypeItems, setPageTypeItems] = useState<any[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const listRef = useRef<HTMLUListElement>(null);
-
-  const currentPageTypeName = pageTypes?.find((_pageType) => _pageType.key === pageType)?.name;
 
   useEffect(() => {
     setSearchQuery("");
@@ -38,11 +27,9 @@ const PageTypeField = ({
 
     if (!href || loading || !startsWith(href, "pageType:")) return;
     const initHref = split(href, ":");
-    const _pageType = get(initHref, 1, "page") || "page";
-    setPageType(_pageType);
 
     (async () => {
-      const initalValue = await searchPageTypeItems(_pageType, [get(initHref, 2, "page")]);
+      const initalValue = await searchPageTypeItems("", [get(initHref, 2, "page")]);
       if (initalValue && Array.isArray(initalValue)) {
         setSearchQuery(get(initalValue, [0, "name"], ""));
       }
@@ -55,18 +42,18 @@ const PageTypeField = ({
       if (isEmpty(query)) {
         setPageTypeItems([]);
       } else {
-        const pageTypeItemResponse = await searchPageTypeItems(pageType, query);
+        const pageTypeItemResponse = await searchPageTypeItems("", query);
         setPageTypeItems(pageTypeItemResponse);
       }
       setLoading(false);
       setSelectedIndex(-1);
     },
-    [pageType],
+    [],
     300,
   );
 
   const handleSelect = (pageTypeItem: any) => {
-    const href = ["pageType", pageType, pageTypeItem.primaryPage ?? pageTypeItem.id];
+    const href = ["pageType", pageTypeItem.pageType || "page", pageTypeItem.primaryPage ?? pageTypeItem.id];
     if (!href[1]) return;
     onChange(href.join(":"));
     setSearchQuery(pageTypeItem.name);
@@ -124,32 +111,23 @@ const PageTypeField = ({
 
   return (
     <div>
-      <select name="pageType" value={pageType} onChange={(e) => setPageType(e.target.value)}>
-        {map(pageTypes, (col) => (
-          <option key={col.key} value={col.key}>
-            {col.name}
-          </option>
-        ))}
-      </select>
-      {pageType && (
-        <div className="group relative mt-2 flex items-center">
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => handleSearch(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={t(`Search ${currentPageTypeName ?? ""}`)}
-            className="w-full rounded-md border border-gray-300 p-2 pr-16"
-          />
-          <div className="absolute bottom-2 right-2 top-3 flex items-center gap-1.5">
-            {searchQuery && (
-              <button onClick={clearSearch} className="text-gray-400 hover:text-gray-600" title={t("Clear search")}>
-                <Cross1Icon className="h-4 w-4" />
-              </button>
-            )}
-          </div>
+      <div className="group relative flex items-center">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => handleSearch(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("Search pages")}
+          className="w-full rounded-md border border-gray-300 p-2 pr-16"
+        />
+        <div className="absolute bottom-2 right-2 top-3 flex items-center gap-1.5">
+          {searchQuery && (
+            <button onClick={clearSearch} className="text-gray-400 hover:text-gray-600" title={t("Clear search")}>
+              <Cross1Icon className="h-4 w-4" />
+            </button>
+          )}
         </div>
-      )}
+      </div>
 
       {(loading || !isEmpty(pageTypeItems) || (isSearching && isEmpty(pageTypeItems))) && (
         <div className="absolute z-40 mt-2 max-h-40 w-full max-w-[250px] overflow-y-auto rounded-md border border-border bg-background shadow-lg">
@@ -237,11 +215,7 @@ const LinkField = ({ schema, formData, onChange, name }: FieldProps) => {
           )}
         </select>
         {linkType === "pageType" && !isEmpty(pageTypes) ? (
-          <PageTypeField
-            href={href}
-            pageTypes={pageTypes}
-            onChange={(href: string) => onChange({ ...formData, href })}
-          />
+          <PageTypeField href={href} onChange={(href: string) => onChange({ ...formData, href })} />
         ) : null}
         <input
           id={`root.${name}.href`}

--- a/src/pages/chaibuilder-pages.tsx
+++ b/src/pages/chaibuilder-pages.tsx
@@ -23,7 +23,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useAtom } from "jotai";
 import { cloneDeep, get, pick } from "lodash-es";
 import { Loader } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { previewUrlAtom } from "./atom/preview-url";
 import { BlurContainer } from "./client/components/chai-loader";
 import { usePageLockStatus } from "./client/components/page-lock/page-lock-hook";
@@ -100,8 +100,8 @@ type ChaiBuilderInnerProps = ChaiWebsiteBuilderProps;
 const ChaiBuilderInner = ({ ...props }: ChaiBuilderInnerProps) => {
   const { data: websiteData } = useWebsiteData();
   const { data: siteWideUsage } = useSiteWideUsage();
-  const {data: uiLibraries} = useUILibraries();
-  const {  collections, pageTypes, websiteSettings: websiteConfig } = websiteData;
+  const { data: uiLibraries } = useUILibraries();
+  const { collections, pageTypes, websiteSettings: websiteConfig } = websiteData;
   const fallbackLang = useMemo(() => websiteConfig?.fallbackLang || "en", [websiteConfig]);
   const { data: accessData, isFetching: isFetchingAccessData } = useCheckUserAccess();
   const roleAndPermissions = accessData || DEFAULT_ROLES_AND_PERMISSIONS;
@@ -118,7 +118,7 @@ const ChaiBuilderInner = ({ ...props }: ChaiBuilderInnerProps) => {
   const { onSave } = usePagesSavePage();
   const { mutateAsync: getBlockAsyncProps } = useGetBlockAysncProps();
   const { getPartialBlocks, getPartialBlockBlocks } = usePartialBlocksFn();
-  const { mutateAsync: searchPageTypePages } = useSearchPageTypePages();
+  const { searchPages } = useSearchPageTypePages();
   const { mutateAsync: updateSettings } = useUpdateWebsiteFields();
   const gotoPage = useGotoPage();
 
@@ -169,14 +169,6 @@ const ChaiBuilderInner = ({ ...props }: ChaiBuilderInnerProps) => {
     return uiLibraries?.some((library: any) => library.isSiteLibrary);
   }, [uiLibraries]);
 
-  // * SEARCH for page types
-  const searchPageTypeItems = useCallback(
-    async (pageType: string, query: string) => {
-      return await searchPageTypePages({ pageType, query });
-    },
-    [searchPageTypePages],
-  );
-
   return (
     <>
       {isFetchingPageAllData && (
@@ -218,7 +210,7 @@ const ChaiBuilderInner = ({ ...props }: ChaiBuilderInnerProps) => {
         blocks={isFetchingPageAllData ? [] : blocks}
         theme={cloneDeep(currentTheme)}
         pageTypes={pageTypes}
-        searchPageTypeItems={searchPageTypeItems}
+        searchPageTypeItems={searchPages}
         askAiCallBack={askAiCallBack}
         onSave={async ({ blocks: _blocks, needTranslations, partialIds, linkPageIds, designTokens }) => {
           if (!page) return true;

--- a/src/pages/hooks/project/use-page-types.ts
+++ b/src/pages/hooks/project/use-page-types.ts
@@ -1,9 +1,10 @@
 import { ACTIONS } from "@/pages/constants/ACTIONS";
 import { useFetch } from "@/pages/hooks/utils/use-fetch";
 import { ChaiPageType } from "@/types/actions";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 import { useApiUrl } from "./use-builder-prop";
+import { useWebsitePages } from "@/pages";
 
 export const usePageTypes = () => {
   const apiUrl = useApiUrl();
@@ -24,24 +25,29 @@ export const usePageType = (pageType: string) => {
 };
 
 export const useSearchPageTypePages = () => {
-  const apiUrl = useApiUrl();
-  const fetchAPI = useFetch();
-  return useMutation({
-    mutationFn: async ({ pageType, query }: any) => {
-      try {
-        return (
-          fetchAPI(apiUrl, {
-            action: ACTIONS.SEARCH_PAGES,
-            data: {
-              pageType,
-              query: Array.isArray(query) && query.length > 0 ? query[0] : query,
-            },
-          }) || []
-        );
-      } catch (_error) {
-        console.error(_error);
-        return [];
+  const { data: primaryPages } = useWebsitePages();
+  const searchPages = useCallback(
+    async (_pageType: string, query: string | string[]) => {
+      if (!primaryPages || !query) return [];
+
+      // When query is an array (ID lookup during initialization)
+      if (Array.isArray(query)) {
+        return primaryPages.filter((page: any) => query.includes(page.id));
       }
+
+      // Normal text search — exclude partials (no slug) and dynamic pages
+      const lowerQuery = query.toLowerCase();
+      return primaryPages.filter(
+        (page: any) =>
+          page.slug &&
+          !page.dynamic &&
+          (page.id === query ||
+            (page.name || "").toLowerCase().includes(lowerQuery) ||
+            (page.slug || "").toLowerCase().includes(lowerQuery)),
+      );
     },
-  });
+    [primaryPages],
+  );
+
+  return { searchPages };
 };


### PR DESCRIPTION
This pull request refactors how page type search functionality is handled in the `link` widget and related hooks. The main improvements are simplifying the `PageTypeField` by removing the explicit page type selector and centralizing the page search logic to use the website's primary pages directly, resulting in a cleaner and more intuitive user experience.

**Refactoring and simplification of page type search:**

* The `PageTypeField` component in `link.tsx` no longer receives or manages `pageTypes` or a selected `pageType`. The page type dropdown and related state have been removed, and the search now operates directly on all primary pages. The search input always prompts "Search pages" instead of referencing a specific page type. [[1]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL12-L32) [[2]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL41-R32) [[3]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL58-R56) [[4]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL127-R120) [[5]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL152) [[6]](diffhunk://#diff-2728c4fbbd8b7edebba55ce6825efb906a30cb9e1781144b36d2624cd95b165eL240-R218)

* The `useSearchPageTypePages` hook has been rewritten to provide a `searchPages` function. This function searches through the website's primary pages, supporting both ID lookups (for initialization) and text queries, and excludes partials and dynamic pages from search results. [[1]](diffhunk://#diff-9255d45c9b45089603ae6917470191368977317433670404e8faa5b40104821fL4-R7) [[2]](diffhunk://#diff-9255d45c9b45089603ae6917470191368977317433670404e8faa5b40104821fL27-R52)

**Prop and API updates:**

* The `searchPageTypeItems` prop is now passed as `searchPages` throughout the codebase, reflecting the new unified search approach. [[1]](diffhunk://#diff-bf063770001ab74c3a8c90116bf7fa9303c43feb5807f0154131c5ac50e68753L121-R121) [[2]](diffhunk://#diff-bf063770001ab74c3a8c90116bf7fa9303c43feb5807f0154131c5ac50e68753L221-R213)

* Unused imports and callback code related to the old page type search implementation have been removed for clarity and maintainability. [[1]](diffhunk://#diff-bf063770001ab74c3a8c90116bf7fa9303c43feb5807f0154131c5ac50e68753L26-R26) [[2]](diffhunk://#diff-bf063770001ab74c3a8c90116bf7fa9303c43feb5807f0154131c5ac50e68753L172-L179)

These changes streamline the user interface for linking to pages and consolidate the logic for searching pages, making the codebase easier to maintain and the feature more user-friendly.