### PR TITLE
feat: add dynamic property inheritance for lang pages & prevent self-referencing in parent selection

### DIFF
--- a/src/actions/builder/create-page.ts
+++ b/src/actions/builder/create-page.ts
@@ -101,6 +101,25 @@ export class CreatePageAction extends ChaiBaseAction<CreatePageActionData, Creat
       blocks = await this.getTemplateBlocks(data.template, appId);
     }
 
+    let dynamic = data.dynamic ?? false;
+    let dynamicSlugCustom = data.dynamicSlugCustom ?? "";
+
+    if (data.primaryPage) {
+      const { data: primaryPageData } = await safeQuery(() =>
+        db.query.appPages.findFirst({
+          where: and(eq(schema.appPages.id, data.primaryPage as string), eq(schema.appPages.app, appId)),
+          columns: {
+            dynamic: true,
+            dynamicSlugCustom: true,
+          },
+        }),
+      );
+      if (primaryPageData) {
+        dynamic = primaryPageData.dynamic ?? false;
+        dynamicSlugCustom = primaryPageData.dynamicSlugCustom ?? "";
+      }
+    }
+
     // Prepare the page data
     const pageData = {
       app: appId,
@@ -110,8 +129,8 @@ export class CreatePageAction extends ChaiBaseAction<CreatePageActionData, Creat
       parent: data.parent ?? null,
       lang: !data.primaryPage ? "" : (data.lang ?? ""),
       primaryPage: data.primaryPage ?? null,
-      dynamic: data.dynamic ?? false,
-      dynamicSlugCustom: data.dynamicSlugCustom ?? "",
+      dynamic: dynamic,
+      dynamicSlugCustom: dynamicSlugCustom,
       blocks: blocks,
       seo: data.seo ?? {
         title: data.name,

--- a/src/actions/builder/update-page.ts
+++ b/src/actions/builder/update-page.ts
@@ -108,6 +108,8 @@ export class UpdatePageAction extends ChaiBaseAction<UpdatePageActionData, Updat
         await this.updatePageInDatabase(data.id, filteredData);
       }
 
+      await this.syncDynamicFieldsToSecondaryPages(data.id, filteredData);
+
       return await this.buildResponse(data.id, filteredData);
     } catch (error) {
       return this.handleExecutionError(error);
@@ -317,6 +319,35 @@ export class UpdatePageAction extends ChaiBaseAction<UpdatePageActionData, Updat
     const updatedPage = await this.fetchUpdatedPageData(pageId);
     return { page: updatedPage };
   }
+
+  /**
+   * Sync dynamic and dynamicSlugCustom fields to secondary pages based on primary page.
+   */
+  private async syncDynamicFieldsToSecondaryPages(pageId: string, filteredData: Partial<UpdatePageActionData>) {
+    const dataKeys = keys(filteredData);
+    const hasDynamicUpdates = dataKeys.includes("dynamic") || dataKeys.includes("dynamicSlugCustom");
+
+    if (!hasDynamicUpdates) return;
+
+    // 1. Sync the dynamic flags directly to secondary pages
+    const syncData: any = {};
+    if (dataKeys.includes("dynamic")) syncData.dynamic = filteredData.dynamic;
+    if (dataKeys.includes("dynamicSlugCustom")) syncData.dynamicSlugCustom = filteredData.dynamicSlugCustom;
+
+    const { error } = await safeQuery(() =>
+      db
+        .update(schema.appPages)
+        .set(syncData)
+        .where(and(eq(schema.appPages.primaryPage, pageId), eq(schema.appPages.app, this.appId))),
+    );
+
+    if (error) {
+      console.error("Failed to sync dynamic fields to secondary pages:", error);
+    }
+
+  }
+
+
 
   /**
    * Handle execution errors with proper error transformation

--- a/src/pages/client/components/parent-page-selector.tsx
+++ b/src/pages/client/components/parent-page-selector.tsx
@@ -193,7 +193,7 @@ export function ParentPageSelector({
             const indentLevel = getIndentationLevel(page.slug);
             const indent = indentLevel > 0 ? getIndentation(indentLevel) : "";
             const displaySlug = getDisplaySlug(page.slug);
-            const isDisabled = currentPage?.id === page.id || page.slug.startsWith(currentPage?.slug);
+            const isDisabled = currentPage?.id === page.id || page.slug.startsWith((currentPage?.slug || "") + "/");
 
             if (isDisabled) {
               return null;


### PR DESCRIPTION

correct parent filter logic in parent-page-selector to avoid hiding valid parent pages for dynamic routes